### PR TITLE
On branch edburns-msft-gh-618-jdbc-version

### DIFF
--- a/specification/pom.xml
+++ b/specification/pom.xml
@@ -20,14 +20,14 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
         <relativePath/>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>jakarta.platform</groupId>
     <artifactId>platform-specs</artifactId>
     <packaging>pom</packaging>
-    <version>11.0</version>
+    <version>11.0.0-M1</version>
     <name>Jakarta EE Platform Specifications</name>
 
     <properties>
@@ -61,7 +61,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.4.1</version>
+                <version>3.4.1</version>
                 <executions>
                     <execution>
                         <id>enforce-versions</id>
@@ -71,12 +71,12 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>[1.8.0,)</version>
-                                    <message>You need JDK8 or later</message>
+                                    <version>[21,)</version>
+                                    <message>You need JDK21 or later</message>
                                 </requireJavaVersion>
                                 <requireMavenVersion>
-                                    <version>3.0.5</version>
-                                    <message>You need Maven 3.0.5 or later</message>
+                                    <version>3.9.0</version>
+                                    <message>You need Maven 3.9.0 or later</message>
                                 </requireMavenVersion>
                             </rules>
                         </configuration>
@@ -246,7 +246,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.2</version>
+                <version>3.0.1</version>
                 <configuration>
                     <mavenExecutorId>forked-path</mavenExecutorId>
                     <useReleaseProfile>false</useReleaseProfile>
@@ -256,7 +256,7 @@
                     <dependency>
                         <groupId>org.apache.maven.scm</groupId>
                         <artifactId>maven-scm-provider-gitexe</artifactId>
-                        <version>1.9.4</version>
+                        <version>2.0.1</version>
                     </dependency>
                 </dependencies>
             </plugin>
@@ -267,7 +267,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.6.0</version>
                 <inherited>false</inherited>
                 <executions>
                     <execution>

--- a/specification/pom.xml
+++ b/specification/pom.xml
@@ -27,7 +27,7 @@
     <groupId>jakarta.platform</groupId>
     <artifactId>platform-specs</artifactId>
     <packaging>pom</packaging>
-    <version>11.0.0-M1</version>
+    <version>11.0-M1</version>
     <name>Jakarta EE Platform Specifications</name>
 
     <properties>

--- a/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
@@ -981,8 +981,7 @@ Connector architecture must support deploying and using a JDBC driver
 that has been written and packaged as a resource adapter using the
 Connector architecture.
 
-The JDBC 4.2 specification is available at
-_https://jcp.org/en/jsr/detail?id=221_ .
+Every release of Jakarta EE declares a minimum required version of Java SE. For discussion, let this be Java SE N. Compatible implementations of Jakarta EE must support the latest version of the JDBC API mentioned in the Java SE N javadocs for the package `java.sql`. These javadocs typically have a link to the corresponding specification at `jcp.org`. 
 
 [[a2553]]
 ===== Jakarta XML Web Services (JAX-WS™) Requirements (Optional)


### PR DESCRIPTION
modified:   specification/pom.xml
- Increment versions.
modified:   specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
- Remove reference to JDBC 4.2.
- Replace with verbiage asking the reader to look up the version from the package javadoc for `java.sql`, which does state the version and provides a link to the corresponding JSR.