### PR TITLE
Remove ManagedBean and use CDI Managed Beans instead in the Platform spec

### DIFF
--- a/specification/src/main/asciidoc/managedbeans/RevisionHistory.adoc
+++ b/specification/src/main/asciidoc/managedbeans/RevisionHistory.adoc
@@ -1,5 +1,8 @@
 [appendix]
 == Revision History
+=== Changes in Milestone 1 Release Draft for EE 11
+* Removed Managed Beans and replaced it with CDI Managed Beans.
+
 === Changes in Final Release for EE10
 Marked for deprecation in the Platform Specification.
 

--- a/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
@@ -226,12 +226,6 @@ language. Jakarta Enterprise Beans 2.x API group.]
 |Y
 |REQ
 
-|Managed Beans (Deprecated)
-|Y
-|Y
-|Y
-|REQ
-
 |Messaging
 |Y
 |Y
@@ -1747,11 +1741,6 @@ corresponding specifications and summarized in the following table.
 |Y
 |Y
 
-|ManagedBean
-|Y
-|Y
-|Y
-
 |DataSourceDefinition
 |Y
 |Y
@@ -1809,20 +1798,6 @@ _jakarta.persistence.validation.factory_ .
 Additional requirements on Jakarta EE platform
 containers are specified in the Bean Validation specification, which can
 be found at _https://jakarta.ee/specifications/bean-validation_ .
-
-=== Managed Beans 2.0 Requirements
-
-The Managed Beans specification defines a
-lightweight component model that supports the basic lifecycle model,
-resource injection facility and interceptor service present in the Jakarta EE platform.
-
-[NOTE]
-====
-Managed Beans is being deprecated in EE 10 for removal in a later version. The Managed Beans specification is a legacy notion that has been superceeded by the Jakarta Contexts and Dependency Injection specification and CDI beans should be used in place of Managed Beans.
-====
-
-The Managed Beans specification can be found
-at _https://jakarta.ee/specifications/managedbeans_ .
 
 === Interceptors 2.1 Requirements
 

--- a/specification/src/main/asciidoc/platform/Profiles.adoc
+++ b/specification/src/main/asciidoc/platform/Profiles.adoc
@@ -198,7 +198,6 @@ The following technologies are required:
 * Jakarta JSON Processing 2.1*
 * Jakarta JSON Binding 3.0*
 * Jakarta Mail 2.1*
-* Jakarta Managed Beans 2.0
 * Jakarta Messaging 3.1*
 * Jakarta Persistence  3.1*
 * Jakarta RESTful Web Services 3.1*
@@ -222,9 +221,10 @@ The following technologies are optional:
 *Note:* technologies with an asterisk after them represent updated versions.
 
 The following technologies are deprecated:
-* Jakarta Managed Beans 2.0
+* NONE
 
 The following technologies are removed:
 
+* Jakarta Managed Beans
 * Entity Beans, both Container and Bean Managed Persistence
 * Embeddable EJB Container

--- a/specification/src/main/asciidoc/platform/ResourcesNamingInjection.adoc
+++ b/specification/src/main/asciidoc/platform/ResourcesNamingInjection.adoc
@@ -120,7 +120,7 @@ ConnectionFactory in the component’s environment.
 application components of references to the default Jakarta Concurrency objects
 in the component’s environment.
 * <<a2067, Managed Bean References>> describes the use by eligible application
-components of references to Managed Beans.
+components of references to CDI Managed Beans.
 * <<a2099, Bean Manager References>> describes the use by eligible application
 components of references to a _BeanManager_ object in the component’s
 environment.
@@ -131,7 +131,7 @@ Dependency Injection APIs.
 
 Jakarta EE application clients, enterprise beans,
 and web components are required to have access to a JNDI naming
-environment.footnote:[Note that Jakarta™ Managed Beans are required to have
+environment.footnote:[Note that CDI Managed Beans are required to have
 access to the JNDI naming environment of their calling component.]
 The containers for these application
 component types are required to provide the naming environment support
@@ -511,8 +511,8 @@ supported only in Jakarta™ RESTful Web Services components managed by CDI.]
 injection in CDI managed beans.]
 |CDI-style managed beans footnote:[We use this term to refer to classes that become
 managed beans per the rules in the CDI specification, thus excluding managed beans
-declared using the _ManagedBean_ annotation as well as Jakarta™ Enterprise Beans
-session beans, both of which would be managed beans even in the absence of CDI.]
+declared using Jakarta™ Enterprise Beans session beans, which would be managed bean
+even in the absence of CDI.]
 
 decorators footnote:[Interceptors cannot be bound to decorators.]
 
@@ -4234,13 +4234,13 @@ it must be mapped by the Jakarta EE Product Provider to a preconfigured
 Jakarta Concurrency object for the Jakarta EE Product Provider.
 
 [[a2067]]
-=== Managed Bean References
+=== CDI Managed Bean References
 
 This section describes the metadata
 annotations and deployment descriptor entries that allow an application
-to obtain instances of a Managed Bean.
+to obtain instances of a CDI Managed Bean.
 
-An instance of a named Managed Bean can be
+An instance of a named CDI Managed Bean can be
 obtained by looking up its name in JNDI using the same naming scheme
 used for Jakarta Enterprise Beans components:
 
@@ -4251,16 +4251,16 @@ java:module/<bean-name>
 ----
 
 The latter will only work within the module
-the Managed Bean is declared in.
+the CDI Managed Bean is declared in.
 
 Each such lookup must return a new instance.
 
 Alternatively, the _Resource_ annotation can
-be used to request the injection of a Managed Bean given either its type
+be used to request the injection of a CDI Managed Bean given either its type
 or its name. If a name is specified using the _lookup_ element then the
-type of the resource can be any of the types that the Managed Bean class
+type of the resource can be any of the types that the CDI Managed Bean class
 implements, including any of its interfaces. If no name is specified,
-the type must be the Managed Bean class itself. (Note that the _name_
+the type must be the CDI Managed Bean class itself. (Note that the _name_
 element of the _Resource_ annotation serves an entirely different
 purpose than the _lookup_ element, consistently with other uses of
 _Resource_ in this specification.) The _authenticationType_ and
@@ -4308,13 +4308,13 @@ should add an _injection-target_ child element to _resource-ref_.)
 ==== Application Component Provider’s Responsibilities
 
 The Application Component Provider is
-responsible for requesting injection of a Managed Bean or for looking it
+responsible for requesting injection of a CDI Managed Bean or for looking it
 up in JNDI using an appropriate name.
 
 ==== Jakarta EE Product Provider’s Responsibilities
 
 The Jakarta EE Product Provider is responsible
-for providing appropriate instances of the requested Managed Bean class
+for providing appropriate instances of the requested CDI Managed Bean class
 as required by this specification.
 
 [[a2099]]
@@ -4377,8 +4377,6 @@ injection is supported on managed beans. There are currently three ways
 for a class to become a managed bean:
 
 . Being a Jakarta Enterprise Beans session bean component.
-. Being annotated with the _ManagedBean_
-annotation.
 . Satisfying the conditions described in the
 CDI specification.
 


### PR DESCRIPTION
Jakarta Annotations 3.0 removes `@ManagedBean`. This is an attempt to apply this change to the platform:

* removes Managed Beans spec
* replaces _Managed Beans_ by _CDI Managed Beans_ on places related to JNDI/resource lookups

relates to #701 