### PR TITLE
On branch edburns-msft-jea-290-copyedits Copyediting changes to release plan from 2024-01-30 Platform Project meeting

### DIFF
--- a/jakartaee11/JakartaEE11ReleasePlan.md
+++ b/jakartaee11/JakartaEE11ReleasePlan.md
@@ -205,6 +205,7 @@ We are proposing to deliver Jakarta EE 11 in a set of waves similar to those del
 #### Wave 1
 
 - Jakarta Annotations*
+- Jakarta JSON Processing* (service release)
 
 #### Wave 2
 
@@ -214,13 +215,13 @@ We are proposing to deliver Jakarta EE 11 in a set of waves similar to those del
 
 #### Wave 3
 
-- Jakarta Activation*
+- Jakarta Activation* (service release)
 - Jakarta Contexts and Dependency Injection*
 
 #### Wave 4
 
 - Jakarta JSON Binding
-- Jakarta Mail*
+- Jakarta Mail* (service release)
 - Jakarta SOAP with Attachments
 - Jakarta XML Binding
 

--- a/jakartaee11/JakartaEE11ReleasePlan.md
+++ b/jakartaee11/JakartaEE11ReleasePlan.md
@@ -121,7 +121,7 @@ List of specifications in Jakarta EE 11 Platform, Jakarta EE 11 Web Profile, and
 - Jakarta Debugging Support for Other Languages 2.0
 - Jakarta Dependency Injection 2.0.1
 - Jakarta Enterprise Beans 4.0.1
-- Jakarta Expression Language 4.0
+- Jakarta Expression Language 6.0
 - Jakarta Faces 4.1*
 - Jakarta Interceptors 2.2*
 - Jakarta JSON Binding 3.0
@@ -208,7 +208,7 @@ We are proposing to deliver Jakarta EE 11 in a set of waves similar to those del
 
 #### Wave 2
 
-- Jakarta Expression Language
+- Jakarta Expression Language*
 - Jakarta Interceptors*
 - Jakarta Lang Model (may be released with Jakarta CDI [Core] in wave 3)
 

--- a/jakartaee11/JakartaEE11ReleasePlan.md
+++ b/jakartaee11/JakartaEE11ReleasePlan.md
@@ -144,6 +144,7 @@ List of specifications in Jakarta EE 11 Platform, Jakarta EE 11 Web Profile, and
 
 ### Proposed Updates to Platform
 
+- Jakarta CDI
 - Jakarta Data 1.0
 - Jakarta Activation
 - Jakarta Annotations
@@ -165,6 +166,7 @@ List of specifications in Jakarta EE 11 Platform, Jakarta EE 11 Web Profile, and
 
 ### Proposed Updates to Web Profile
 
+- Jakarta CDI
 - Jakarta Annotations
 - Jakarta Validation
 - Jakarta Concurrency
@@ -198,61 +200,60 @@ As stated earlier, all component Specifications which plan a Major or Minor rele
 
 ### Waves
 
-We are proposing to deliver Jakarta EE 11 in a set of waves similar to those delivered in the previous Jakarta EE releases. These waves are somewhat related to the dependency tree of specifications. We aim to deliver specifications with a low number of dependencies first followed by other specifications.
+We are proposing to deliver Jakarta EE 11 in a set of waves similar to those delivered in the previous Jakarta EE releases. These waves are somewhat related to the dependency tree of specifications. We aim to deliver specifications with a low number of dependencies first followed by other specifications. (updated specifications marked with asterisks)
 
 #### Wave 1
 
-- Jakarta Annotations
+- Jakarta Annotations*
 
 #### Wave 2
 
 - Jakarta Expression Language
-- Jakarta Interceptors
+- Jakarta Interceptors*
 - Jakarta Lang Model (may be released with Jakarta CDI [Core] in wave 3)
 
 #### Wave 3
 
-- Jakarta Activation
-- Jakarta Contexts and Dependency Injection
+- Jakarta Activation*
+- Jakarta Contexts and Dependency Injection*
 
 #### Wave 4
 
 - Jakarta JSON Binding
-- Jakarta Mail
+- Jakarta Mail*
 - Jakarta SOAP with Attachments
 - Jakarta XML Binding
 
 #### Wave 5
 
-- Jakarta Authorization
+- Jakarta Authorization*
 - Jakarta Batch
-- Jakarta Persistence
-- Jakarta RESTful Web Services
-- Jakarta Server Pages
-- Jakarta Servlet
-- Jakarta Validation
-- Jakarta WebSocket
+- Jakarta Persistence*
+- Jakarta RESTful Web Services*
+- Jakarta Server Pages*
+- Jakarta Servlet*
+- Jakarta Validation*
+- Jakarta WebSocket*
 - Jakarta XML Web Services
 
 #### Wave 6
 
-- Jakarta Authentication
-- Jakarta Concurrency
-- Jakarta Faces
+- Jakarta Authentication*
+- Jakarta Concurrency*
+- Jakarta Faces*
 - Jakarta Messaging
 - Jakarta Standard Tag Library
-- Jakarta Platform Core Profile
 
 #### Wave 7
 
-- Jakarta Security
-- Jakarta Data
+- Jakarta Security*
+- Jakarta Data*
 
 #### Wave 8
 
-- Jakarta Platform (including appropriate content formerly in CDI EE)
-- Jakarta Platform Web Profile (including appropriate content formerly in CDI EE)
-- Jakarta Platform Core Profile
+- Jakarta Platform (including appropriate content formerly in CDI EE)*
+- Jakarta Platform Web Profile (including appropriate content formerly in CDI EE)*
+- Jakarta Platform Core Profile*
 
 ### Platform and Web Profile Release Candidate
 

--- a/jakartaee11/JakartaEE11ReleasePlan.md
+++ b/jakartaee11/JakartaEE11ReleasePlan.md
@@ -211,7 +211,7 @@ We are proposing to deliver Jakarta EE 11 in a set of waves similar to those del
 
 - Jakarta Expression Language*
 - Jakarta Interceptors*
-- Jakarta Lang Model (may be released with Jakarta CDI [Core] in wave 3)
+- Jakarta Lang Model* (may be released with Jakarta CDI [Core] in wave 3)
 
 #### Wave 3
 
@@ -252,9 +252,9 @@ We are proposing to deliver Jakarta EE 11 in a set of waves similar to those del
 
 #### Wave 8
 
-- Jakarta Platform (including appropriate content formerly in CDI EE)*
-- Jakarta Platform Web Profile (including appropriate content formerly in CDI EE)*
-- Jakarta Platform Core Profile*
+- Jakarta Platform* (including appropriate content formerly in CDI EE)
+- Jakarta Web Profile* (including appropriate content formerly in CDI EE)
+- Jakarta Core Profile*
 
 ### Platform and Web Profile Release Candidate
 


### PR DESCRIPTION
Copyedit changes observed in 2024-01-30 platform call meeting. Uncontroversial. No normative changes.

modified:   jakartaee11/JakartaEE11ReleasePlan.md

Edit wave plan to have asterisks for modified specs, as in other section. Add CDI to section "Proposed Updates to Platform" and "Proposed Updates to Web". Remove "Core Profile" from Wave 7.