### PR TITLE
Jakarta EE 11 spec updates

### DIFF
--- a/namespace/ReleaseStages.txt
+++ b/namespace/ReleaseStages.txt
@@ -48,7 +48,7 @@ Jakarta Security
 Jakarta Server Faces
 
 Stage 6
-Jakarta EE Full Profile
+Jakarta EE Platform
 Jakarta EE Web Profile
 
 

--- a/specification/pom.xml
+++ b/specification/pom.xml
@@ -39,7 +39,6 @@
         <status>DRAFT</status>
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
         <revisiondate>${maven.build.timestamp}</revisiondate>
-        <managedbean.version>2.1-SNAPSHOT</managedbean.version>  <!-- override <version> for Managed Beans spec-->
     </properties>
 
     <scm>

--- a/specification/src/main/asciidoc/coreprofile/Introduction.adoc
+++ b/specification/src/main/asciidoc/coreprofile/Introduction.adoc
@@ -15,7 +15,7 @@ It is worth noting that Core Profile products are allowed to ship with more tech
 required ones. It is conceivable that products will offer a choice at
 installation time/or build time between different configurations, some richer in
 extensions, or even allow for complete customization beyond the required
-core (“à la carte” installation).
+core technologies (“à la carte” installation).
 
 === Determining Applicable Requirements
 
@@ -45,12 +45,8 @@ self-explanatory. For example, Core Profile products must implement the Jakarta 
 
 The fourth category is the most complex. The Jakarta Core Profile TCK attempts to validate the ability to combine the individual component specifications into composite test applications.
 
-=== Acknowledgements for Jakarta EE 10.0
+=== Acknowledgements for Jakarta EE 10 and Beyond
 
-The Jakarta EE 10.0 specification was created by the Jakarta EE Platform
-Specification Project with guidance provided by the Jakarta EE Working Group.
-
-=== Acknowledgements for Jakarta EE 11.0
-
-The Jakarta EE 11.0 specification was created by the Jakarta EE Platform
-Specification Project with guidance provided by the Jakarta EE Working Group.
+The Jakarta EE Core Profile specification version 10 and beyond were created by the Jakarta EE Platform
+Specification Project with guidance provided by the Jakarta EE Working Group
+(_https://jakarta.ee/_).

--- a/specification/src/main/asciidoc/platform/ApplicationAssemblyDeployment.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationAssemblyDeployment.adoc
@@ -58,7 +58,7 @@ image::deploy.svg[]
 ==== Component Creation
 
 The Jakarta Enterprise Beans, Jakarta Servlet, application client, and
-Jakarta Connector specifications include the XML Schema definition of the
+Jakarta Connectors specifications include the XML Schema definition of the
 associated module level deployment descriptors and component packaging
 architecture required to produce Jakarta EE modules. (The application
 client specification is found in
@@ -1151,7 +1151,7 @@ be deployable.
 Jakarta EE modules listed in the Jakarta EE application deployment descriptor
 or discovered using the rules above and read the Jakarta EE module
 deployment descriptor, if present in the package. See the Enterprise
-Jakarta Beans, Jakarta Servlet, Jakarta Connector and application client
+Jakarta Beans, Jakarta Servlet, Jakarta Connectors and application client
 specifications for the required location and name of the deployment
 descriptor for each component type. Deployment descriptors are optional
 for all module types. (The application client specification is
@@ -1211,7 +1211,7 @@ deployment descriptor.
 ====
 
 The jakarta name is a trademarked name that has restrictions on its usage. For Jakarta EE, the specification
-projects produce APIs that utilize the jakarta.* namespace. As defined in the Jakarta EE Specification Process 1.3, APIs
+projects produce APIs that utilize the jakarta.* namespace. As defined in the Jakarta EE Specification Process 1.4, APIs
 artifacts (API jars, javadoc, schemas) produced by a specification project are the only artifacts that must make use of the
 jakarta.* package namespace. The jakarta namespace must not be used for any deployment, including applications, TCKs, tools,
 libraries or any other assets. Attempting to deploy an application under the jakarta.* package namespace may result in deployment

--- a/specification/src/main/asciidoc/platform/ApplicationClients.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationClients.adoc
@@ -303,7 +303,7 @@ file. Note that this name is case-sensitive.
 <<a3404, Jakarta EE Application Client XML Schema Structure>> shows the structure of the Jakarta EE
 application-client XML Schema. The Jakarta EE application-client XML Schema
 is located at
-_https://jakarta.ee/xml/ns/jakartaee/application-client_10.xsd_.
+_https://jakarta.ee/xml/ns/jakartaee/application-client_11.xsd_.
 
 [[a3404]]
 .Jakarta EE Application Client XML Schema Structure

--- a/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
@@ -311,6 +311,9 @@ The following Jakarta EE Technologies were removed from the Jakarta EE Platform.
 |Jakarta EE Technology
 |Status
 
+|Jakarta XML Registries
+|Removed in Jakarta EE 9
+
 |Embeddable EJB Container (Jakarta Enterprise Beans, Core Features 4.0, Chapter 17)
 |Removed in Jakarta EE 10
 
@@ -1145,7 +1148,7 @@ specification can be found at _https://jakarta.ee/specifications/debugging/_ .
 === Standard Tag Library for Jakarta Server Pages 3.0 Requirements
 
 Jakarta Standard Tag Library specification defines a standard tag library that
-makes it easier to develop Jakarta Server Pages Pages. All Jakarta EE products are required
+makes it easier to develop Jakarta Server Pages. All Jakarta EE products are required
 to provide a Jakarta Standard Tag Library for use by all Jakarta Server Pages.
 
 The Jakarta Standard Tag Library for Jakarta Server Pages

--- a/specification/src/main/asciidoc/platform/Introduction.adoc
+++ b/specification/src/main/asciidoc/platform/Introduction.adoc
@@ -17,13 +17,13 @@ the integrity of the enterprise.
 transactions are accurately and promptly processed.
 
 In most cases, enterprise services are
-implemented as _multitier applications_. The middle tiers integrate
+implemented as _multi-tier applications_. The middle tiers integrate
 existing EISs with the business functions and data of the new service.
 Maturing web technologies are used to provide first tier users with easy
 access to business complexities, and eliminate or drastically reduce
 user administration and training.
 
-The Jakarta™ EE Platform reduces the cost and complexity of developing multitier, enterprise
+The Jakarta™ EE Platform reduces the cost and complexity of developing multi-tier, enterprise
 services. Jakarta EE applications can be rapidly deployed and easily
 enhanced as the enterprise responds to competitive pressures.
 

--- a/specification/src/main/asciidoc/platform/PlatformOverview.adoc
+++ b/specification/src/main/asciidoc/platform/PlatformOverview.adoc
@@ -52,18 +52,15 @@ A profile is a configuration of the Jakarta EE
 platform targeted at a specific class of applications.
 
 Profiles are not a new concept, nor are they
-unique to the Jakarta EE platform. The Jakarta EE Specification process: “A
-Specification that includes by reference a collection of Specifications and possibly additional requirements. APIs from the referenced Platform
-Edition must be included according to the referencing rules set out in
-that Platform Edition Specification. Other referenced specifications
-must be referenced in their entirety.”
+unique to the Jakarta EE platform. The Jakarta EE Specification Process defines a profile as: “A
+Specification that includes by reference a collection of Specifications and possibly additional requirements.”
 
 All Jakarta EE profiles share a set of common
 features, such as naming and resource injection, packaging rules,
 security requirements, etc. This guarantees a degree of uniformity
 across all products and, indirectly, applications that fall under the
 “Jakarta EE platform” umbrella. This also ensures that developers who are
-familiar with a certain profile, or with the full platform, can move
+familiar with a certain profile, or with the platform, can move
 easily to other profiles, avoiding excessive compartmentalization of
 skills and experience.
 
@@ -85,7 +82,7 @@ transactions in a servlet container. In isolation, neither the Jakarta Servlet
 specification nor the Jakarta Transactions specification defines a
 complete programming model for portable applications. This specification
 fills that gap by introducing its own set of requirements that pertain
-to the combination of servlets and Jakarta Transactions. These requirements must be
+to the combination of servlets and transactions. These requirements must be
 satisfied by any Jakarta EE profile-based product that includes those two
 technologies, thus offering application developers a more complete
 programming model shared across all relevant Jakarta EE profiles.
@@ -120,7 +117,7 @@ intended target.
 
 === Application Components
 
-The Jakarta EE runtime environment defines four
+The Jakarta EE runtime environment defines three
 application component types that a Jakarta EE product must support:
 
 * Application clients are Java programming
@@ -151,7 +148,7 @@ protocol.
 
 ==== Jakarta EE Server Support for Application Components
 
-The Jakarta EE servers provide deployment,
+Jakarta EE servers provide deployment,
 management, and execution support for conforming application components.
 Application components can be divided into three categories according to
 their dependence on a Jakarta EE server:
@@ -252,7 +249,7 @@ these standard services are actually provided by Java SE.
 The HTTP client-side API is defined by the _java.net_ package. The
 HTTP server-side API is defined and used by the Jakarta RESTful Web Services,
 Jakarta Servlet, Jakarta Server Pages, and Jakarta Server Faces
-interfaces and by the web services support that is an optional part of
+interfaces and by Jakarta XML Web Services support that is no longer a required part of
 the Jakarta EE platform.
 
 ==== HTTPS
@@ -307,7 +304,7 @@ publish-subscribe model. This specification requires a Jakarta Messaging provide
 implements both point-to-point messaging as well as publish-subscribe
 messaging. The Jakarta EE Product Provider must also provide a
 preconfigured, default Jakarta Messaging connection factory for use by the application
-in accessing this JMS provider. See
+in accessing this Jakarta Messaging provider. See
 <<a2025, Default Jakarta Messaging Connection Factory>>.
 
 ==== Java Naming and Directory Interface™ (JNDI)
@@ -350,7 +347,7 @@ EE applications.
 Jakarta Connectors is a Jakarta EE SPI
 that allows resource adapters that support access to Enterprise
 Information Systems to be plugged in to any Jakarta EE product. The
-Connector architecture defines a standard set of system-level contracts
+Jakarta Connectors specification defines a standard set of system-level contracts
 between a Jakarta EE server and a resource adapter. The standard contracts
 include:
 
@@ -463,6 +460,8 @@ For the Platform specification, the following two features are removed.
 
 * Entity Beans, both Container and Bean Managed Persistence
 * Embeddable EJB Container
+
+See <<a2333, Removed Jakarta Technologies>>.
 
 === Interoperability
 
@@ -709,7 +708,7 @@ application and the management and monitoring of an application server.
 ==== System Component Provider
 
 A variety of system level components may be
-provided by System Component Providers. Jakarta Connectors
+provided by System Component Providers. The Jakarta Connectors specification
 defines the primary APIs used to provide resource adapters of many
 types. These resource adapters may connect to existing enterprise
 information systems of many types, including databases and messaging
@@ -738,10 +737,10 @@ components that conform to these APIs and policies.
 
 The Jakarta EE Service Provider Interfaces (SPIs)
 define the contract between the Jakarta EE platform and service providers
-that may be plugged into a Jakarta EE product. The connector APIs define
+that may be plugged into a Jakarta EE product. The Jakarta Connectors APIs define
 service provider interfaces for integrating resource adapters with a
-Jakarta EE application server. Resource adapter components implementing the
-connector APIs are called Connectors. The Jakarta Authorization APIs
+Jakarta EE application server. Resource adapter components implementing the Jakarta
+Connectors APIs are called connectors. The Jakarta Authorization APIs
 define service provider interfaces for integrating security
 authorization mechanisms with a Jakarta EE application server.
 
@@ -764,7 +763,8 @@ The Jakarta EE Product Provider is required to
 publish the installed application components on the industry-standard
 protocols. This specification defines the mapping of servlets and server
 pages to the HTTP and HTTPS protocols, and the mapping of Jakarta Enterprise Beans components
-to IIOP and SOAP protocols.
+to IIOP and SOAP protocols.  Jakarta SOAP with Attachments is no longer required by Jakarta EE 11.
+See <<a2333, Removed Jakarta Technologies>>.
 
 ==== Deployment Descriptors and Annotations
 
@@ -773,13 +773,13 @@ annotations are used to communicate the needs of application components
 to the Deployer. The deployment descriptor and class file annotations
 are a contract between the Application Component Provider or Assembler
 and the Deployer. The Application Component Provider or Assembler is
-required to specify the application component’s external resource
+required to specify the application components' external resource
 requirements, security requirements, environment parameters, and so
-forth in the component’s deployment descriptor or through class file
+forth in the components' deployment descriptor or through class file
 annotations. The Jakarta EE Product Provider is required to provide a
 deployment tool that interprets the Jakarta EE deployment descriptors and
 class file annotations and allows the Deployer to map the application
-component’s requirements to the capabilities of a specific Jakarta EE
+components' requirements to the capabilities of a specific Jakarta EE
 product and environment.
 
 === Changes in J2EE 1.3

--- a/specification/src/main/asciidoc/platform/PlatformOverview.adoc
+++ b/specification/src/main/asciidoc/platform/PlatformOverview.adoc
@@ -773,13 +773,13 @@ annotations are used to communicate the needs of application components
 to the Deployer. The deployment descriptor and class file annotations
 are a contract between the Application Component Provider or Assembler
 and the Deployer. The Application Component Provider or Assembler is
-required to specify the application components' external resource
+required to specify the application component's external resource
 requirements, security requirements, environment parameters, and so
-forth in the components' deployment descriptor or through class file
+forth in the component's deployment descriptor or through class file
 annotations. The Jakarta EE Product Provider is required to provide a
 deployment tool that interprets the Jakarta EE deployment descriptors and
 class file annotations and allows the Deployer to map the application
-components' requirements to the capabilities of a specific Jakarta EE
+component's requirements to the capabilities of a specific Jakarta EE
 product and environment.
 
 === Changes in J2EE 1.3

--- a/specification/src/main/asciidoc/platform/Profiles.adoc
+++ b/specification/src/main/asciidoc/platform/Profiles.adoc
@@ -37,7 +37,7 @@ they do, they need to obey all the relevant requirements mandated by the
 profile specification.
 
 A product may implement two or more Jakarta EE
-profiles, or the full platform and one or more Jakarta EE profiles, as long
+profiles, or the platform and one or more Jakarta EE profiles, as long
 as their combined requirements do not give rise to conflicts.
 
 === Profile Definition

--- a/specification/src/main/asciidoc/platform/RelatedDocuments.adoc
+++ b/specification/src/main/asciidoc/platform/RelatedDocuments.adoc
@@ -79,7 +79,7 @@ _Jakarta™ Batch Specification, Version 2.1_. Available at: _https://jakarta.ee
 
 _Jakarta™ Data Specification, Version 1.0_. Available at: _https://jakarta.ee/specifications/data/1.0/_
 
-_Jakarta EE Specification Process (JESP), Version 1.2_. Available at: _https://jakarta.ee/about/jesp/_
+_Jakarta EE Specification Process (JESP), Version 1.4_. Available at: _https://jakarta.ee/about/jesp/_
 
 Extension Mechanism Architecture, Available at
 _https://docs.oracle.com/javase/8/docs/technotes/guides/extensions/index.html_

--- a/specification/src/main/asciidoc/platform/ResourcesNamingInjection.adoc
+++ b/specification/src/main/asciidoc/platform/ResourcesNamingInjection.adoc
@@ -9,12 +9,13 @@ annotations defined in the Java Metadata specification and features
 defined in the Java Naming and Directory Interface™ (JNDI)
 specification. The _Resource_ annotation described here is defined in
 more detail in the Jakarta Annotations specification. The _EJB_
-annotation described here is defined in more detail in the Enterprise
-JavaBeans specification. The _PersistenceUnit_ and _PersistenceContext_
+annotation described here is defined in more detail in the Jakarta Enterprise
+Beans specification. The _PersistenceUnit_ and _PersistenceContext_
 annotations described here are defined in more detail in the Jakarta
 Persistence specification. The _Inject_ annotation described here is
 defined in the Dependency Injection for Java specification, and its
-usage in Jakarta EE applications is defined in the CDI specification.
+usage in Jakarta EE applications is defined in the Jakarta Contexts 
+and Dependency Injection (CDI) specification.
 
 === Overview
 
@@ -25,7 +26,7 @@ address the following two issues:
 be able to customize the behavior of an application’s business logic
 without accessing the application’s source code. Typically this will
 involve specification of parameter values, connection to external
-resources, and so on. Deployment descriptors provide this capability
+resources, and so on. Deployment descriptors provide this capability.
 * Applications must be able to access resources
 and external information in their operational environment without
 knowledge of how the external information is named and organized in that
@@ -102,20 +103,20 @@ resources in the component’s environment.
 components of references to Jakarta Messaging _Destination_ resources in the
 component’s environment.
 * <<a1863, Mail Session Definition>> describes the use by eligible application
-components of references to Mail _Session_ resources in the component’s
+components of references to Jakarta Mail _Session_ resources in the component’s
 environment.
 * <<a1917, Connector Connection Factory Definition>> describes the use by eligible
-application components of references to Connector connection factory
+application components of references to Jakarta Connectors connection factory
 resources in the component’s environment.
 * <<a1967, Connector Administered Object Definition>> describes the use by
-eligible application components of references to Connector administered
+eligible application components of references to Jakarta Connectors administered
 object resources in the component’s environment.
 * <<a2009, Default Data Source>> describes the use by eligible application
-components of references to the default DataSource in the component’s
+components of references to the default _DataSource_ in the component’s
 environment.
 * <<a2025, Default Jakarta Messaging Connection Factory>> describes the use by eligible
 application components of references to the default Jakarta Messaging
-ConnectionFactory in the component’s environment.
+_ConnectionFactory_ in the component’s environment.
 * <<a2042, Default Jakarta Concurrency Objects>> describes the use by eligible
 application components of references to the default Jakarta Concurrency objects
 in the component’s environment.
@@ -227,7 +228,7 @@ product-dependent, but it must be possible to deploy multiple
 applications to a single application server instance.
 
 Note that in environments in which an
-application is deployed multiple times—such as, for example, in cloud
+application is deployed multiple times—for example, in cloud
 environments, where multiple instances of the same application might be
 deployed on behalf of multiple tenants—the namespace for each
 application instance would be disjoint from the namespace of any other
@@ -409,18 +410,16 @@ injected into multiple fields or methods of multiple classes.
 
 The specifications for the various application
 component types describe which classes may be annotated for injection,
-as summarized in <<a651, Component classes supporting injection>>.
-
-The component classes listed in
-<<a651, Component classes supporting injection>> with support level “Standard” all support Jakarta EE
-resource injection, as well as PostConstruct and PreDestroy callbacks.
+are summarized in <<a651, Component classes supporting injection>>.
+The component classes with a support level of “Standard” all support Jakarta EE
+resource injection, as well as _PostConstruct_ and _PreDestroy_ callbacks.
 In addition, if CDI is enabled—which it is by default—these classes also
 support CDI injection, as described in
 <<a2112, Support for Dependency Injection>>, and the use of interceptors.footnote:[Note that the use of
 interceptors defined by means of the Interceptors annotation is supported in the
-absence of CDI for Jakarta™ Enterprise Beans and Jakarta™ Managed Bean components.]
-The component classes listed with support level “Limited” only support Jakarta
-EE field injection and the PostConstruct callback. Note that these are
+absence of CDI for Jakarta™ Enterprise Beans components.]
+The component classes listed with a support level of “Limited” only support Jakarta
+EE field injection and the _PostConstruct_ callback. Note that these are
 application client main classes, where field injection is into static
 fields.
 
@@ -436,11 +435,11 @@ be put into service.
 [cols=3, options=header]
 .Component classes supporting injection
 |===
-|Spec
+|Specification
 |Classes supporting injection
 |Support level
 
-|Servlet
+|Jakarta Servlet
 |servlets
 
 servlet filters
@@ -468,18 +467,9 @@ Standard
 
 |Jakarta Server Faces
 |managed classes footnote:[See the Jakarta™ Server Faces
-specification section Jakarta™ Server Faces Managed Classes and Jakarta™ Annotations” for
+specification section Jakarta Faces Managed Classes and Jakarta EE Annotations” for
 a list of these managed classes.]
 |Standard
-
-|Jakarta Web Services
-|service endpoints
-
-handlers
-
-|Standard
-
-Standard
 
 |Jakarta RESTful Web Services
 |Jakarta RESTful Web Services components footnote:[Resource and CDI injection is
@@ -487,7 +477,7 @@ supported only in Jakarta™ RESTful Web Services components managed by CDI.]
 
 |Standard
 
-|WebSocket
+|Jakarta WebSocket
 |endpoints
 |Standard
 
@@ -495,7 +485,7 @@ supported only in Jakarta™ RESTful Web Services components managed by CDI.]
 |beans
 |Standard
 
-|Interceptor
+|Jakarta Interceptors
 |interceptors footnote:[Interceptors cannot be bound to other interceptors.]
 |Standard
 
@@ -508,15 +498,11 @@ entity listeners
 
 Standard
 
-|Managed Beans
-|managed beans
-|Standard
-
-|CDI footnote:[See the CDI specification for requirements related to resource
+|Jakarta CDI footnote:[See the CDI specification for requirements related to resource
 injection in CDI managed beans.]
 |CDI-style managed beans footnote:[We use this term to refer to classes that become
 managed beans per the rules in the CDI specification, thus excluding managed beans
-declared using Jakarta™ Enterprise Beans session beans, which would be managed bean
+declared using Jakarta™ Enterprise Beans session beans, which would be managed beans
 even in the absence of CDI.]
 
 decorators footnote:[Interceptors cannot be bound to decorators.]
@@ -552,7 +538,7 @@ resources follows the Java language overriding rules for visibility of
 fields and methods. A method definition that overrides a method on a
 superclass defines the resource, if any, to be injected into that
 method. An overriding method may request injection even though the
-superclass method does not request injection, it may request injection
+superclass method does not request injection. It may request injection
 of a different resource than is requested by the superclass, or it may
 request no injection even though the superclass method requests
 injection.
@@ -590,7 +576,7 @@ classes that support injection also support the _PostConstruct_
 annotation. All classes for which the container manages the full
 lifecycle of the object also support the _PreDestroy_ annotation.
 
-Starting with Java EE 7, CDI support is
+CDI support is
 enabled by default. CDI bean-defining annotations and the _beans.xml_
 descriptor are used to determine which classes are CDI beans and
 eligible for injection into other objects. Similarly, the annotation
@@ -645,8 +631,8 @@ so is undefined.
 The rules for how a deployment descriptor
 entry may override an _EJB_ annotation are included in the Jakarta Enterprise
 Beans specification. The rules for how a deployment descriptor entry may
-override a _WebServiceRef_ annotation are included in the Web Services
-for Jakarta EE specification.
+override a _WebServiceRef_ annotation are included in the Jakarta XML Web Services
+specification.
 
 A PostConstruct method may be specified using
 either the _PostConstruct_ annotation on the method or the
@@ -1125,7 +1111,7 @@ Enterprise Beans references. It does so in three sections, the first describing
 annotations for injecting Jakarta Enterprise Beans references, the second
 describing the API for accessing Jakarta Enterprise Beans references, and the
 third describing the syntax for declaring the Jakarta Enterprise Beans
-references in a deployment descriptor
+references in a deployment descriptor.
 
 ===== Injection of Jakarta Enterprise Beans Entries
 
@@ -1140,7 +1126,7 @@ The following example illustrates how an
 application component uses the _EJB_ annotation to reference an instance
 of an enterprise bean. The referenced bean is a stateful session bean.
 The enterprise bean reference will have the name
-_java:comp/env/com.example.ExampleBean/myCart_ in the naming context,
+_java:comp/env/com.acme.example.ExampleBean/myCart_ in the naming context,
 where _ExampleBean_ is the name of the class of the referencing bean and
 _com.acme.example_ is its package. The target of the reference is not
 named and must be resolved by the Deployer, unless there is only one
@@ -1181,7 +1167,7 @@ example uses a JNDI name in the application namespace.
 [source,java]
 ----
 @EJB(
-  lookup="java:app/cartModule/ShoppingCart",
+  lookup ="java:app/cartModule/ShoppingCart",
   description = "The shopping cart for this application"
 )
 private ShoppingCart myOtherCart;
@@ -1194,26 +1180,26 @@ Bean reference would be to the bean’s home interface. For example:
 [source,java]
 ----
 @EJB(
-  name="ejb/shopping-cart",
-  beanInterface=ShoppingCartHome.class,
-  beanName="cart1",
-  description="The shopping cart for this application"
+  name = "ejb/shopping-cart",
+  beanInterface = ShoppingCartHome.class,
+  beanName = "cart1",
+  description = "The shopping cart for this application"
 )
 private ShoppingCartHome myCartHome;
 ----
 
 If the _ShoppingCart_ bean were instead
 written to the no-interface client view and implemented by bean class
-_ShoppingCartBean.class_, the Jakarta Enterprise Bean reference would have
-type _ShoppingCartBean.class_. For example:
+_ShoppingCartBean_, the Jakarta Enterprise Bean reference would have
+type _ShoppingCartBean_. For example:
 
 [source,java]
 ----
 @EJB(
-  name="ejb/shopping-cart",
-  beanInterface=ShoppingCartBean.class,
-  beanName="cart1",
-  description="The shopping cart for this application"
+  name = "ejb/shopping-cart",
+  beanInterface = ShoppingCartBean.class,
+  beanName = "cart1",
+  description = "The shopping cart for this application"
 )
 private ShoppingCartBean myCart;
 ----
@@ -1240,7 +1226,7 @@ application component’s environment using JNDI.
 
 The following example illustrates how an
 application component uses a Jakarta Enterprise Bean reference to locate the
-home interface of an enterprise bean.
+interface of an enterprise bean.
 
 [source,java]
 ----
@@ -1251,35 +1237,28 @@ public void changePhoneNumber(...) {
 
   // Look up the home interface of the EmployeeRecord
   // enterprise bean in the environment.
-  Object result = initCtx.lookup("java:comp/env/ejb/EmplRecord");
-
-  // Convert the result to the proper type.
-  EmployeeRecordHome emplRecordHome = (EmployeeRecordHome)
-         javax.rmi.PortableRemoteObject.narrow(result,
-            EmployeeRecordHome.class);
+  EmployeeRecord result = (EmployeeRecord) initCtx.lookup("java:comp/env/ejb/EmplRecord");
  ...
 }
 ----
 
 In the example, the Application Component
 Provider assigned the environment entry _ejb/EmplRecord_ as the Jakarta
-Enterprise Bean reference name to refer to the remote home interface of an
+Enterprise Bean reference name to refer to the remote interface of an
 enterprise bean.
 
 [[a1011]]
 ===== Declaration of Jakarta Enterprise Beans References
 
-Although the Jakarta Enterprise Bean reference is an entry in the
+Although a Jakarta Enterprise Bean reference is an entry in the
 application component’s environment, the Application Component Provider
 must not use a _env-entry_ element to declare it. Instead, the
-Application Component Provider must declare all the Jakarta Enterprise Beans
+Application Component Provider must declare all the Jakarta Enterprise Bean
 references using either annotations on the application component’s code or the
 _ejb-ref_ or _ejb-local-ref_ elements of the deployment descriptor. This allows
 the consumer of the application component’s JAR file (the Application
-Assembler or Deployer) to discover all the Jakarta Enterprise Beans references
-used by the application component. Deployment descriptor entries may also be used to
-specify injection of a Jakarta Enterprise Bean reference into an application
-component.
+Assembler or Deployer) to discover all the Jakarta Enterprise Bean references
+used by the application component. 
 
 Each _ejb-ref_ or _ejb-local-ref_ element
 describes the interface requirements that the referencing application
@@ -1292,7 +1271,7 @@ local home and component interfaces. The _ejb-ref_ element contains a
 _description_ element and the _ejb-ref-name_, _ejb-ref-type_, _home_,
 and _remote_ elements. The _ejb-local-ref_ element contains a
 _description_ element and the _ejb-ref-name_, _ejb-ref-type_,
-_local-home_, and _local_ elements
+_local-home_, and _local_ elements.
 
 The _ejb-ref-name_ element specifies the Jakarta Enterprise Bean
 reference name. Its value is the environment entry name used in the
@@ -1336,21 +1315,18 @@ declaration of Jakarta Enterprise Beans references in the deployment descriptor.
   </description>
   <ejb-ref-name>ejb/EmplRecord</ejb-ref-name>
   <ejb-ref-type>Entity</ejb-ref-type>
-  <home>com.wombat.empl.EmployeeRecordHome</home>
   <remote>com.wombat.empl.EmployeeRecord</remote>
 </ejb-ref>
 
 <ejb-ref>
   <ejb-ref-name>ejb/Payroll</ejb-ref-name>
   <ejb-ref-type>Entity</ejb-ref-type>
-  <home>com.aardvark.payroll.PayrollHome</home>
   <remote>com.aardvark.payroll.Payroll</remote>
 </ejb-ref>
 
 <ejb-ref>
   <ejb-ref-name>ejb/PensionPlan</ejb-ref-name>
   <ejb-ref-type>Session</ejb-ref-type>
-  <home>com.wombat.empl.PensionPlanHome</home>
   <remote>com.wombat.empl.PensionPlan</remote>
   <lookup-name>java:global/personnel/retirement/PensionPlan</lookup-name>
 </ejb-ref>
@@ -1369,7 +1345,7 @@ an enterprise bean as follows:
 * The Application Assembler uses the optional
 _ejb-link_ element of the _ejb-ref_ or _ejb-local-ref_ element of the
 referencing application component. The value of the _ejb-link_ element
-is the name of the target enterprise bean. This is the name as defined
+is the name of the target enterprise bean. The name is defined
 by the metadata annotation (or default) on the bean class or in the
 _ejb-name_ element for the target enterprise bean. The target enterprise
 bean can be in any ejb-jar file or war file in the same Jakarta EE
@@ -1379,19 +1355,19 @@ enterprise beans to have unique names within an entire Jakarta EE
 application, the Application Assembler may use either of the following
 two syntaxes in the _ejb-link_ element of the referencing application
 component.
-* The Application Assembler specifies the
+** The Application Assembler specifies the
 module name of the ejb-jar file or war file containing the referenced
 enterprise bean and appends the _ejb-name_ of the target bean separated by
-“/”. The module name is the base name of the bundle with no filename
+“/”. The module name is the base name of the archive file with no filename
 extension, unless specified in the deployment descriptor.
-* The Application Assembler specifies the
+** The Application Assembler specifies the
 path name of the ejb-jar file containing the referenced enterprise bean
 and appends the _ejb-name_ of the target bean separated from the path
 name by “ _#_ ”. The path name is relative to the referencing
 application component JAR file. In this manner, multiple beans with the
 same _ejb-name_ may be uniquely identified when the Application
-Assembler cannot change _ejb-name_s.
-* Alternatively to the use of _ejb-link_, the
+Assembler cannot change the _ejb-name_ elements.
+* Alternative to the use of _ejb-link_, the
 Application Assembler may use the _lookup-name_ element to reference the
 target enterprise bean component by means of one of its JNDI names. It is an
 error for both _ejb-link_ and _lookup-name_ to appear inside an _ejb-ref_
@@ -1424,7 +1400,6 @@ reference.
   </description>
   <ejb-ref-name>ejb/EmplRecord</ejb-ref-name>
   <ejb-ref-type>Entity</ejb-ref-type>
-  <home>com.wombat.empl.EmployeeRecordHome</home>
   <remote>com.wombat.empl.EmployeeRecord</remote>
   <ejb-link>EmployeeRecord</ejb-link>
 </ejb-ref>
@@ -1449,7 +1424,6 @@ unit but in a different ejb-jar file.
   </description>
   <ejb-ref-name>ejb/Product</ejb-ref-name>
   <ejb-ref-type>Entity</ejb-ref-type>
-  <home>com.acme.products.ProductHome</home>
   <remote>com.acme.products.Product</remote>
   <ejb-link>../products/product.jar#ProductEJB</ejb-link>
 </ejb-ref>
@@ -1461,7 +1435,7 @@ _ejb-link_ element to indicate an enterprise bean reference to the
 _ShoppingCart_ enterprise bean that is in the same Jakarta EE application
 unit but in a different ejb-jar file. The reference was originally
 declared in the application component’s code using an annotation. The
-Assembler provides only the link to the bean.
+Assembler provides only the link to the enterprise bean.
 
 [source,xml]
 ----
@@ -1475,7 +1449,7 @@ Assembler provides only the link to the bean.
 
 The same effect can be obtained by using the
 _lookup-name_ element instead, using an appropriate JNDI name for the
-target bean.
+target enterprise bean.
 
 [source,xml]
 ----
@@ -1517,7 +1491,7 @@ declaration to include both an _ejb-link_ and a _lookup-name_ element.
 The following example illustrates the use of
 the _lookup-name_ element to bind an _ejb-ref_ to a target enterprise
 bean in the operational environment. The reference was originally
-declared in the bean’s code using an annotation. The target enterprise
+declared in the enterprise bean’s code using an annotation. The target enterprise
 bean has _ejb-name_ _ShoppingCart_ and is deployed in the stand-alone
 module _products.jar_.
 
@@ -1555,8 +1529,7 @@ by binding it to a specified compatible target enterprise bean.
 
 A web service reference is similar to an
 Jakarta Enterprise Bean reference, but is used to reference a web service.
-Web service references are fully specified in the Web Service
-specification and the Jakarta Web Service specification.
+Web service references are fully specified in the Jakarta XML Web Services specification.
 
 [[a1120]]
 === Resource Manager Connection Factory References
@@ -1604,7 +1577,7 @@ may be annotated with the _Resource_ annotation. The name and type of
 the factory are as described above. The _authenticationType_ and
 _shareable_ elements of the _Resource_ annotation may be used to control
 the type of authentication desired for the resource and the shareability
-of connection acquired from the factory, as described in the following
+of connections acquired from the factory, as described in the following
 sections.
 
 The following code example illustrates how an
@@ -1851,7 +1824,7 @@ using a well-known JNDI name for the latter.
 
 The Application Component Provider must use the
 _javax.sql.DataSource_ resource manager connection factory type for
-obtaining JDBC API connections.
+obtaining JDBC connections.
 
 The Application Component Provider must use the
 _jakarta.jms.ConnectionFactory_, the _jakarta.jms.QueueConnectionFactory_,
@@ -1859,22 +1832,22 @@ or the _jakarta.jms.TopicConnectionFactory_ for obtaining Jakarta Messaging conn
 
 The Application Component Provider must use the
 _jakarta.mail.Session_ resource manager connection factory type for
-obtaining Jakarta Mail API connections.
+obtaining Jakarta Mail connections.
 
 The Application Component Provider must use the
 _java.net.URL_ resource manager connection factory type for obtaining
 URL connections.
 
 It is recommended that the Application Component
-Provider name JDBC API data sources in the _java:comp/env/jdbc_
+Provider name JDBC data sources in the _java:comp/env/jdbc_
 subcontext, all Jakarta Messaging connection factories in the _java:comp/env/jms_
-subcontext, all Jakarta Mail API connection factories in the
+subcontext, all Jakarta Mail connection factories in the
 _java:comp/env/mail_ subcontext, and all URL connection factories in the
 _java:comp/env/url_ subcontext. Note that resource manager connection
 factory references declared via annotations will not, by default, appear
 in any subcontext.
 
-The Jakarta EE Connector Architecture allows an
+The Jakarta Connectors specification allows an
 application component to use the annotation or API described in this
 section to obtain resource objects that provide access to additional
 back-end systems.
@@ -1910,7 +1883,7 @@ deployment descriptor’s _res-auth_ element is _Container_, the Deployer
 is responsible for configuring the sign on information for the resource
 manager. This is performed in a manner specific to the container and
 resource manager; it is beyond the scope of this specification.
-
++
 For example, if principals must be mapped from
 the security domain and principal realm used at the application
 component level to the security domain and principal realm of the
@@ -2571,7 +2544,7 @@ The Application Component Provider is
 responsible for requesting injection of the _ORB_ object using the
 Resource annotation, or using the defined name to look up the _ORB_
 object. If the _shareable_ element of the _Resource_ annotation is set
-to _false_ , the ORB object injected will not be the shared instance
+to _false_, the ORB object injected will not be the shared instance
 used by other components in the application but instead will be a
 private ORB instance used only by this component.
 
@@ -2594,7 +2567,7 @@ _persistence.xml_ specification for the persistence unit, as described
 in the Jakarta Persistence specification.
 
 The requirements in this section only apply to
-Jakarta EE products that include support for the Jakarta Persistence API.
+Jakarta EE products that include support for Jakarta Persistence.
 
 ==== Application Component Provider’s Responsibilities
 
@@ -2664,7 +2637,7 @@ public class InventoryManagerBean implements InventoryManager {
     Context initCtx = new InitialContext();
 
     // perform JNDI lookup to obtain entity manager factory
-    EntityManagerFactory = (EntityManagerFactory)
+    EntityManagerFactory emf = (EntityManagerFactory)
        initCtx.lookup(
           "java:comp/env/persistence/InventoryAppDB");
 
@@ -2700,7 +2673,7 @@ contains the name of the environment entry used in the application
 component’s code. The name of the environment entry is relative to the
 _java:comp/env_ context (e.g., the name should be
 _persistence/InventoryAppDB_ rather than
-_java:comp/env/persistence/InventoryAppDB_ ). The
+_java:comp/env/persistence/InventoryAppDB_). The
 _persistence-unit-name_ element is the name of the persistence unit, as
 specified in the _persistence.xml_ file for the persistence unit.
 
@@ -2845,7 +2818,7 @@ with their persistence unit, as described in the Jakarta Persistence
 specification.
 
 The requirements in this section only apply to
-Jakarta EE products that include support for the Jakarta Persistence API.
+Jakarta EE products that include support for Jakarta Persistence.
 
 ==== Application Component Provider’s Responsibilities
 
@@ -2922,7 +2895,7 @@ public class InventoryManagerBean implements InventoryManager {
     Context initCtx = new InitialContext();
 
     // JNDI lookup to obtain container-managed entity manager
-    EntityManager = (EntityManager)
+    EntityManager em = (EntityManager)
        initCtx.lookup(
           "java:comp/env/persistence/InventoryAppMgr");
     ...
@@ -2961,7 +2934,7 @@ _java:comp/env_ context (e.g., the name should be
 _persistence/InventoryAppMgr_ rather than
 _java:comp/env/persistence/InventoryAppMgr_ ). The
 _persistence-unit-name_ element is the name of the persistence unit, as
-specified in the _persistence.xml_ file for the persistence unit. The
+specified in the _persistence.xml_ file. The
 _persistence-context-type_ element specifies whether a
 transaction-scoped or extended persistence context is to be used. Its
 value is either _Transaction_ or _Extended_. If the persistence context
@@ -2988,7 +2961,7 @@ bean illustrated in the previous subsection.
        application.
     </description>
     <persistence-context-ref-name>
-       persistence/InventoryAppDB
+       persistence/InventoryAppMgr
     </persistence-context-ref-name>
     <persistence-unit-name>
        InventoryManagement
@@ -3018,7 +2991,7 @@ For example,
        application.
     </description>
     <persistence-context-ref-name>
-       persistence/InventoryAppDB
+       persistence/InventoryAppMgr
     </persistence-context-ref-name>
     <persistence-unit-name>
        ../lib/inventory.jar#InventoryManagement
@@ -3096,7 +3069,7 @@ perform the tasks described in the previous subsection.
 * Provide the implementation of the entity
 manager classes for the persistence units that are configured with the
 container. This implementation may be provided by the container
-directory or by the container in conjunction with a third-party
+directly or by the container in conjunction with a third-party
 persistence provider, as described in the Jakarta Persistence
 specification.
 
@@ -3104,8 +3077,8 @@ specification.
 
 The System Administrator is typically responsible for the following:
 
-* Add, remove, and configure entity manager
-factories in the server environment.
+* Add, remove, and configure entity managers
+in the server environment.
 
 In some scenarios, these tasks can be performed
 by the Deployer.
@@ -3162,7 +3135,7 @@ required by this specification.
 
 This section describes the metadata annotations
 and deployment descriptor entries that allow an application to obtain
-instances of the Validation _Validator_ and _ValidatorFactory_
+instances of the Jakarta Validation _Validator_ and _ValidatorFactory_
 types.
 
 Applications that need to use those interfaces
@@ -3175,9 +3148,9 @@ annotation must not be specified.
 
 [source,java]
 ----
-@Resource ValidatorFactory validatorFactory;
-
 @Resource Validator validator;
+
+@Resource ValidatorFactory validatorFactory;
 ----
 
 For Validator objects, the default validation
@@ -3208,8 +3181,8 @@ reference may also be declared in a deployment descriptor in the same
 way as a resource environment reference.
 
 In order to customize the returned
-_ValidatorFactory_, a Jakarta Enterprise Beans, web or application client module may
-specify a Validation XML deployment descriptor, as described in the
+_ValidatorFactory_, an enterprise bean, web or application client module may
+specify a Validation XML deployment descriptor, as described in the Jakarta
 Validation specification.
 
 A validation deployment descriptor only
@@ -3242,7 +3215,7 @@ non-contextual objects using CDI, as described in
 <<a2112, Support for Dependency Injection>>.
 These objects must be used to configure the default
 _ValidatorFactory_ available at _java:comp/ValidatorFactory_ in
-accordance with the bootstrapping APIs described by the Validation
+accordance with the bootstrapping APIs described by the Jakarta Validation
 specification.
 
 The default _ValidatorFactory_ is a single
@@ -3262,7 +3235,7 @@ configuration of resources that it requires in its operational
 environment.
 
 Each application has a set of “physical”
-resources and services that it depends on (database storage, queueing,
+resources and services that it depends on (database storage, queuing,
 mail, etc.) and which need to be made available to it when it is
 deployed. Such resources may be scoped to the application instance or
 may be shareable. An application may define a dependency upon such
@@ -3343,8 +3316,8 @@ elements.
 
 * In general, the Application Component
 Provider or Assembler should specify values for elements which, if
-changed, would cause the application to break—for example, JNDI name,
-isolation level. If multiple resource definitions are specified for a
+changed, would cause the application to break (for example, JNDI name or
+isolation level). If multiple resource definitions are specified for a
 given resource, they must be consistent.
 * The Jakarta EE Product Provider may choose
 suitable server-specific default values for optional elements for which
@@ -3628,7 +3601,7 @@ the above Jakarta Messaging _ConnectionFactory_ could be referenced as follows:
 
 [source,java]
 ----
-  @Stateless_
+  @Stateless
   public class MySessionBean {
     @Resource(lookup = "java:app/MyJMSCF")
     ConnectionFactory myCF;
@@ -3679,7 +3652,7 @@ definition types are described in
 ==== Jakarta Messaging Destination Definition
 
 An application may define a Jakarta Messaging _Destination_
-resource. A Jakarta Messaging _Destination_ resource is a Jakarta Messaging Queue or Topic.
+resource. A Jakarta Messaging _Destination_ resource is a Jakarta Messaging _Queue_ or _Topic_.
 
 The Jakarta Messaging _Destination_ resource may be defined
 in any of the JNDI namespaces described in
@@ -3696,7 +3669,7 @@ For example:
 ...
 <jms-destination>
   <description>Sample Jakarta Messaging Destination definition</description>
-  <name>java:app/MyJMSDestination</name>
+  <name>java:app/MyJMSQueue</name>
   <interface-name>jakarta.jms.Queue</interface-name>
   <resource-adapter>myJMSRA</resource-adapter>
   <destination-name>myQueue1</destination-name>
@@ -3776,13 +3749,13 @@ definition types are described in
 [[a1863]]
 ==== Mail Session Definition
 
-An application may define a Mail _Session_ resource.
+An application may define a Jakarta Mail _Session_ resource.
 
-The Mail _Session_ resource may be defined in
+The Jakarta Mail _Session_ resource may be defined in
 any of the JNDI namespaces described in
 <<a616, Application Component Environment Namespaces>>.
 
-A Mail _Session_ resource may be defined in a
+A Jakarta Mail _Session_ resource may be defined in a
 web module, enterprise bean module, application client module, or application
 deployment descriptor using the _mail-session_ element.
 
@@ -3812,7 +3785,7 @@ For example:
 ...
 ----
 
-A Mail _Session_ resource may also be defined
+A Jakarta Mail _Session_ resource may also be defined
 using the _MailSessionDefinition_ annotation on a container-managed
 class, such as a servlet or enterprise bean class.
 
@@ -3820,7 +3793,7 @@ For example:
 
 [source,java]
 ----
-  @MailSessionDefinition(_
+  @MailSessionDefinition(
        name="java:app/mail/MySession",
        host="somewhere.myco.com",
        from="some.body@myco.com")
@@ -3829,7 +3802,7 @@ For example:
 The _MailSessionDefinition_ annotation can be
 overridden by a deployment descriptor when the application is deployed.
 
-Once defined, a Mail _Session_ resource may
+Once defined, a Jakarta Mail _Session_ resource may
 be referenced by a component using the _resource-ref_ deployment
 descriptor element or the _Resource_ annotation. For example, the above
 _Destination_ could be referenced as follows:
@@ -3846,13 +3819,13 @@ _Destination_ could be referenced as follows:
 
 The following _MailSessionDefinition_
 annotation elements (and corresponding XML deployment descriptor
-elements) are considered to specify an address for a Mail _Session_
+elements) are considered to specify an address for a Jakarta Mail _Session_
 resource: _host_.
 
 ===== Application Component Provider’s Responsibilities
 
 The Application Component Provider is
-responsible for the definition of a Mail Session using a
+responsible for the definition of a Jakarta Mail Session using a
 _MailSessionDefinition_ annotation or the _mail-session_ deployment
 descriptor element.
 
@@ -3885,14 +3858,14 @@ definition types are described in
 [[a1917]]
 ==== Connector Connection Factory Definition
 
-An application may define Connector
+An application may define Jakarta Connectors
 connection factory resources.
 
 The resource may be defined in any of the
 JNDI namespaces described in
 <<a616, Application Component Environment Namespaces>>.
 
-A Connector connection factory resource may
+A Jakarta Connectors connection factory resource may
 be defined in a web module, enterprise bean module, or application deployment
 descriptor using the _connection-factory_ element.
 
@@ -3902,7 +3875,7 @@ For example:
 ----
 ...
 <connection-factory>
-  <description>Sample Connector resource definition</description>
+  <description>Sample Connector connection factory definition</description>
   <name>java:app/myConnectionFactory</name>
   <interface-name>
      com.eis.ConnectionFactory
@@ -3923,7 +3896,7 @@ For example:
 ...
 ----
 
-A Connector connection factory resource may
+A Jakarta Connectors connection factory resource may
 also be defined using the _ConnectionFactoryDefinition_ annotation on a
 container-managed class, such as a servlet or enterprise bean class.
 
@@ -3934,14 +3907,14 @@ For example:
   @ConnectionFactoryDefinition(
        name="java:app/myConnectionFactory",
        interfaceName="com.eis.ConnectionFactory",
-       resourceAdapter="MyESRA")
+       resourceAdapter="MyEISRA")
 ----
 
 The _ConnectionFactoryDefinition_ annotation
 can be overridden by a deployment descriptor when the application is
 deployed.
 
-Once defined, a Connector connection factory
+Once defined, a Jakarta Connectors connection factory
 resource may be referenced by a component using the _resource-ref_
 deployment descriptor element or the _Resource_ annotation. For example,
 the above Connector connection factory resource could be referenced as
@@ -3960,7 +3933,7 @@ follows:
 ===== Application Component Provider’s Responsibilities
 
 The Application Component Provider is
-responsible for the definition of a Connector connection factory
+responsible for the definition of a Jakarta Connectors connection factory
 resource using a _ConnectionFactoryDefinition_ annotation or the
 _connection-factory_ deployment descriptor element.
 
@@ -3982,7 +3955,7 @@ definition types are described in
 [[a1967]]
 ==== Connector Administered Object Definition
 
-An application may define a Connector
+An application may define a Jakarta Connectors
 administered object resource. The administered object resource may be
 defined in any of the JNDI namespaces described in
 <<a616, Application Component Environment Namespaces>>.
@@ -3991,7 +3964,7 @@ An administered object resource may be
 defined in a web module, enterprise bean module, or application deployment
 descriptor using the _administered-object_ element. Properties that are
 specified are used in the configuration of the administered object, as
-described in the Connector specification.
+described in the Jakarta Connectors specification.
 
 For example:
 
@@ -4040,7 +4013,8 @@ administered object resource could be referenced as follows:
 
 [source,java]
 ----
-  @Stateless public class MySessionBean {
+  @Stateless
+  public class MySessionBean {
     @Resource(lookup="java:app/myAdminObject")
     AdminObject myAdminObject;
     ...
@@ -4080,7 +4054,7 @@ These resources may be defined in
 any of the JNDI namespaces described in
 <<a616, Application Component Environment Namespaces>>
 unless a non-empty list of qualifiers is specified,
-in which case `java:global` is not permitted.
+in which case _java:global_ is not permitted.
 
 These resources may be defined in a web module or application
 deployment descriptor using the _context-service_,

--- a/specification/src/main/asciidoc/platform/Security.adoc
+++ b/specification/src/main/asciidoc/platform/Security.adoc
@@ -57,7 +57,7 @@ mentioned in <<a457, Future Directions>>.
 
 The security behavior of a Jakarta EE environment
 may be better understood by examining what happens in a simple
-application with a web client, a JSP user interface, and enterprise bean
+application with a web client, a Jakarta Server Pages user interface, and enterprise bean
 business logic. (The example is not meant to specify requirements.)
 
 In this example, the web client relies on the
@@ -68,7 +68,7 @@ authenticated session.
 Initial Request::
 
 The web client requests the main application
-URL, shown in <<a253, Initial Request>> .
+URL, shown in <<a253, Initial Request>>.
 
 [[a253]]
 .Initial Request
@@ -86,7 +86,7 @@ The web server returns a form that the web
 client uses to collect authentication data (for example, username and
 password) from the user. The web client forwards the authentication data
 to the web server, where it is validated by the web server, as shown in
-<<a257, Initial Authentication>> .
+<<a257, Initial Authentication>>.
 
 [[a257]]
 .Initial Authentication
@@ -120,22 +120,22 @@ to map the user to any of the permitted roles.
 Fulfilling the Original Request::
 
 If the user is authorized, the web server
-returns the result of the original URLrequest, as shown in
-<<a265, Fulfilling the Original Request>> .
+returns the result of the original URL request, as shown in
+<<a265, Fulfilling the Original Request>>.
 
 [[a265]]
 .Fulfilling the Original Request
 image::Step4.svg[]
 
-In our example, the response URL of a JSP page
+In our example, the response URL of a server page
 is returned, enabling the user to post form data that needs to be
 handled by the business logic component of the application.
 
 Invoking Enterprise Bean Business Methods::
 
-The JSP page performs the remote method call to
+The server page performs the remote method call to
 the enterprise bean, using the user’s credential to establish a secure
-association between the JSP page and the enterprise bean (as shown in
+association between the server page and the enterprise bean (as shown in
 <<a269, Invoking an Enterprise Bean Business Method>> ). 
 The association is implemented as two related
 security contexts, one in the web server and one in the Jakarta Enterprise Beans container.
@@ -157,11 +157,11 @@ authorized” outcome when the container is able to map the caller’s
 credential to a role. A “not authorized” outcome is reached if the
 container is unable to map the caller to any of the permitted roles. A
 “not authorized” result causes an exception to be thrown by the
-container, and propagated back to the calling JSP page.
+container, and propagated back to the calling server page.
 
-If the call “is authorized”, the container
+If the user is authorized, the container
 dispatches control to the enterprise bean method. The result of the
-bean’s execution of the call is returned to the JSP, and ultimately to
+bean’s execution of the call is returned to the server page, and ultimately to
 the user by the web server and the web client.
 
 === Security Architecture
@@ -183,14 +183,14 @@ should not have to know anything about security to write an application.
 to perform authentication and access control according to instructions
 established by the Deployer using deployment attributes, and managed by
 the System Administrator.
-
++
 Note that divorcing the application from
 responsibility for security ensures greater portability of Jakarta EE
 applications.
 
 . Extensibility: The use of platform services by
 security-aware applications must not compromise application portability.
-
++
 This specification provides APIs in the
 component programming model for interacting with container/server
 security information. Applications that restrict their interactions to
@@ -265,12 +265,12 @@ service.
 
 A security policy domain is also sometimes
 referred to as a realm. This specification uses the security policy
-domain, or security domain, terminology.
+domain or security domain terminology.
 
 Security Technology Domain::
 
 A security technology domain is the scope over
-which the same security mechanism (for example Kerberos) is used to
+which the same security mechanism (for example, Kerberos) is used to
 enforce a security policy.
 
 A single security technology domain may include
@@ -350,7 +350,7 @@ methods of the _EJBContext_ and _HttpServletRequest_ interfaces.
 
 These methods allow components to make business
 logic decisions based on the security role of the caller or remote user.
-For example they allow the component to determine the principal name of
+For example, they allow the component to determine the principal name of
 the caller or remote user to use as a database key. (Note that the form
 and content of principal names will vary widely between products and
 enterprises, and portable components will not depend on the actual
@@ -393,7 +393,7 @@ Product Providers may allow for control over
 the quality of protection or other aspects of secure association at
 deployment time. Applications can specify their requirements for access
 to web resources using annotations or elements in their deployment
-descriptor.
+descriptors.
 
 This specification does not define mechanisms
 that an Application Component Provider can use to communicate
@@ -412,7 +412,7 @@ both declarative security and programmatic security.
 Declarative authorization can be used to
 control access to an enterprise bean method and is specified in
 annotations or in the enterprise bean deployment descriptor. The
-_RolesAllows_ , _PermitAll_ , and _DenyAll_ annotations are used to
+_RolesAllowed_, _PermitAll_, and _DenyAll_ annotations are used to
 specify method permissions. An enterprise bean method can also be
 associated with a _method-permission_ element in the deployment
 descriptor. The _method-permission_ element contains a list of methods
@@ -424,8 +424,8 @@ the method. Access to web resources can be protected in a similar
 manner.
 
 Security roles are used in the
-_SecurityContext_ method _isCallerInRole_ , the _EJBContext_ method
-_isCallerInRole_ , and the _HttpServletRequest_ method _isUserInRole_ .
+_SecurityContext_ method _isCallerInRole_, the _EJBContext_ method
+_isCallerInRole_, and the _HttpServletRequest_ method _isUserInRole_.
 Each method returns _true_ if the calling principal is in the specified
 security role.
 
@@ -478,7 +478,7 @@ Requirements in this area are specified in
 
 User authentication is the process by which a
 user proves his or her identity to the system. This authenticated
-identity is then used to perform authorization decisions for accessing
+identity is used to perform authorization decisions for accessing
 Jakarta EE application components. An end user can authenticate using
 either of the two supported client types:
 
@@ -494,7 +494,7 @@ mechanisms. The Deployer or System Administrator determines which method
 to apply to an application or to a group of applications.
 
 * HTTP Basic Authentication
-
++
 HTTP Basic Authentication is the authentication
 mechanism supported by the HTTP protocol. This mechanism is based on a
 username and password. A web server requests a web client to
@@ -503,20 +503,20 @@ realm in which the user is to be authenticated. The web client obtains
 the username and the password from the user and transmits them to the
 web server. The web server then authenticates the user in the specified
 realm (referred to as HTTP Realm in this document).
-
++
 HTTP Basic Authentication is not secure.
 Passwords are sent in simple base64 encoding. The target server is not
 authenticated. Additional protection can be applied to overcome these
 weaknesses. The password may be protected by applying security at the
 transport layer (for example HTTPS) or at the network layer (for
 example, IPSEC or VPN).
-
++
 Despite its limitations, the HTTP Basic
 Authentication mechanism is included in this specification because it is
 widely used in form based applications.
 
 * HTTPS Client Authentication
-
++
 End user authentication using HTTPS (HTTP over
 SSL) is a strong authentication mechanism. This mechanism requires the
 user to possess a Public Key Certificate (PKC). Currently, a PKC is
@@ -526,11 +526,11 @@ browser. For these reasons, HTTPS client authentication is a required
 feature of the Jakarta EE platform.
 
 * Form Based Authentication
-
++
 The look and feel of a login screen cannot be
 varied using the web browser’s built-in authentication mechanisms. This
 specification introduces the ability to package standard HTML or
-servlet/JSP/JSF based forms for logging in, allowing customization of
+servlet, server pages, or server faces based forms for logging in, allowing customization of
 the user interface. The form based authentication mechanism introduced
 by this specification is described in the Servlet specification.
 
@@ -553,7 +553,7 @@ multiple requests from a client. Therefore, it is desirable to:
 . Make login mechanisms and policies a property
 of the environment the web application is deployed in.
 . Be able to use the same login session to
-represent a user to all the applications that he or she accesses.
+represent a user to all the applications that are accessed.
 . Require re-authentication of users only when
 a security policy domain boundary has been crossed.
 
@@ -720,7 +720,7 @@ specification.
 
 Web containers are required to support access
 to web resources by clients that have not authenticated themselves to
-the container. This is the common mode of access to web resources on the
+the container. This mode is the common way to access web resources on the
 Internet.
 
 A web container reports that no user has been
@@ -803,13 +803,13 @@ following:
 
 . Configured Identity. A Jakarta EE container must
 be able to authenticate for access to the resource using a principal and
-authentication data specified by a Deployer at deployment time.The
+authentication data specified by a Deployer at deployment time. The
 authentication must not depend in any way on data provided by the
 application components. Providing for the confidential storage of the
 authentication information is the responsibility of the Product
 Provider.
 . Programmatic Authentication. The Jakarta EE
-product must provide for specification of the principal and
+product must provide for the specification of the principal and
 authentication data for a resource by the application component at
 runtime using appropriate APIs. The application may obtain the principal
 and authentication data through a variety of mechanisms, including
@@ -833,7 +833,7 @@ principal requires delegation of the caller’s identity and credentials
 to the underlying resource manager. In some scenarios, a requesting
 principal can be a delegate of an initiating principal and the resource
 principal is transitively impersonating an initiating principal.
-
++
 The support for principal delegation is
 typically specific to a security mechanism. For example, Kerberos
 supports a mechanism for the delegation of authentication. (Refer to the
@@ -842,37 +842,23 @@ Kerberos v5 specification for more details.)
 . Credentials Mapping. This technique may be
 used when an application server and an EIS support different
 authentication domains. For example:
-. The initiating principal may have been
+* The initiating principal may have been
 authenticated and have public key certificate-based credentials.
-. The security environment for the resource
+* The security environment for the resource
 manager may be configured with the Kerberos authentication service.
-
++
 The application server is configured to map the
 public key certificate-based credentials associated with the initiating
 principal to the Kerberos credentials.
 
 Additional information on resource
-authentication requirements can be found in the Connector specification.
+authentication requirements can be found in the Jakarta Connectors specification.
 
 === Authorization Requirements
 
 To support the authorization models described
 in this chapter, the following requirements are imposed on Jakarta EE
 products.
-
-==== Code Authorization
-
-A Jakarta EE product may restrict the use of
-certain Java SE classes and methods to secure and ensure proper
-operation of the system. The minimum set of permissions that a Jakarta EE
-product is required to grant to a Jakarta EE application is defined in
-<<a2339, Java Platform, Standard Edition (Java SE) Requirements>>. 
-All Jakarta EE products must be capable
-of deploying application components with exactly these permissions.
-
-A Jakarta EE Product Provider may choose to enable
-selective access to resources using the Java protection model. The
-mechanism used is Jakarta EE product dependent.
 
 ==== Caller Authorization
 
@@ -891,10 +877,10 @@ single application within a single Jakarta EE product, the principal name
 returned by the _EJBContext_ method _getCallerPrincipal_ or the
 _SecurityContext_ method _getCallerPrincipal_ must be the same as that
 returned by the first enterprise bean in the call chain. If the first
-enterprise bean in the call chain is called by a servlet or JSP page,
+enterprise bean in the call chain is called by a servlet or server page,
 the principal name must be the same as that returned by the
 _HttpServletRequest_ method _getUserPrincipal_ or the _SecurityContext_
-method _getCallerPrincipal_ in the calling servlet or JSP page.
+method _getCallerPrincipal_ in the calling servlet or server page.
 (However, if the _HttpServletRequest_ or _SecurityContext_ method
 _getCallerPrincipal_ returns _null_ , the principal used in calls to
 enterprise beans is not specified by this specification, although it

--- a/specification/src/main/asciidoc/platform/Security.adoc
+++ b/specification/src/main/asciidoc/platform/Security.adoc
@@ -57,7 +57,7 @@ mentioned in <<a457, Future Directions>>.
 
 The security behavior of a Jakarta EE environment
 may be better understood by examining what happens in a simple
-application with a web client, a Jakarta Server Pages user interface, and enterprise bean
+application with a web client, a Jakarta Pages user interface, and enterprise bean
 business logic. (The example is not meant to specify requirements.)
 
 In this example, the web client relies on the

--- a/specification/src/main/asciidoc/platform/ServiceProviderInterface.adoc
+++ b/specification/src/main/asciidoc/platform/ServiceProviderInterface.adoc
@@ -14,7 +14,7 @@ are packaged and integrated with any Jakarta EE product. Many types of
 service providers can be provided using the Connector API and packaging,
 including JDBC drivers, Jakarta Messaging providers, and Jakarta XML Registries
 providers. All Jakarta EE products must support the Connector APIs, as specified
-in the Connector specification.
+in the Jakarta Connectors specification.
 
 The Jakarta EE Connectors specification is available at
 _https://jakarta.ee/specifications/connectors/_ .

--- a/specification/src/main/asciidoc/platform/TransactionManagement.adoc
+++ b/specification/src/main/asciidoc/platform/TransactionManagement.adoc
@@ -4,7 +4,7 @@ This chapter describes the required Jakarta Enterprise Edition (Jakarta EE)
 transaction management and runtime environment.
 
 Product Providers must transparently support transactions that involve multiple
-components and transactional resources within a single Jakarta EE product, as
+application components and transactional resources within a single Jakarta EE product, as
 described in this chapter.
 This requirement must be met regardless of whether the Jakarta EE product
 is implemented as a single process, multiple processes on the same
@@ -20,16 +20,16 @@ _XATransaction_ transaction level
 
 === Overview
 
-A Jakarta EE Product that includes both a servlet container and an enterprise
+A Jakarta EE product that includes both a servlet container and an enterprise
 bean container must support a transactional application comprised of
 combinations of web application components accessing multiple enterprise beans
 within a single transaction. If the Jakarta EE product also includes support
-for the Connectors specification, each component may also acquire one or more
+for the Jakarta Connectors specification, each component may also acquire one or more
 connections to access one or more transactional resource managers.
 
 For example, in
 <<a475, Servlets/Server Pages Accessing Enterprise Beans>> , the call
-tree starts from a servlet or server pages accessing multiple enterprise beans,
+tree starts from a servlet or server page accessing multiple enterprise beans,
 which in turn may access other enterprise beans. The components access resource
 managers via connections.
 
@@ -59,7 +59,7 @@ EE product in more detail.
 
 === Requirements
 
-This section defines the transaction support requirements of Jakarta EE Products
+This section defines the transaction support requirements of Jakarta EE products
 that must be supported by Product Providers.
 
 ==== Web Components
@@ -82,23 +82,23 @@ objects.
 
 ===== Transaction Requirements
 
-The Jakarta EE platform must meet the following requirements:
+The Jakarta EE product must meet the following requirements:
 
-* The Jakarta EE platform must provide an object implementing the
+* The Jakarta EE product must provide an object implementing the
 _jakarta.transaction.UserTransaction_ interface to all web components.
-The platform must publish the _UserTransaction_ object in the Java™ Naming
+The product must publish the _UserTransaction_ object in the Java™ Naming
 and Directory Interface (JNDI) name space available to web components under the
 name _java:comp/UserTransaction_.
-* The Jakarta EE platform must provide classes
+* The Jakarta EE product must provide classes
 that implement the transactional interceptors, as defined by the Jakarta
 Transactions specification.
 * If a web component invokes an enterprise bean from a thread associated with a
 transaction defined by the Jakarta Transactions specification, the Jakarta EE
-platform must propagate the transaction context with the enterprise bean
+product must propagate the transaction context with the enterprise bean
 invocation. Whether the target enterprise bean will be invoked in this
 transaction context or not is determined by the rules defined in the Jakarta
 Enterprise Beans specification.
-
++
 Note that this transaction propagation
 requirement applies only to invocations of enterprise beans in the same
 Jakarta EE product instance footnote:[A product instance
@@ -118,9 +118,9 @@ context. See the Jakarta Enterprise Beans specification for details.
 
 * If a web component accesses a transactional resource manager from a thread
 associated with a transaction defined by the Jakarta Transactions specification,
-the Jakarta EE platform must ensure that the resource access is included as part
+the Jakarta EE product must ensure that the resource access is included as part
 of the transaction defined by the Jakarta Transactions specification.
-* If a web component creates a thread, the Jakarta EE platform must ensure that the
+* If a web component creates a thread, the Jakarta EE product must ensure that the
 newly created thread is not associated with any transaction defined by the
 Jakarta Transactions specification.
 
@@ -134,11 +134,11 @@ The Product Provider is not required to support transaction context propagation
 via an HTTP request across web components. The HTTP protocol does not support
 such transaction context propagation. When a web component associated with a
 transaction makes an HTTP request to another web component, the transaction
-context is not propagated to the target servlet or page.
+context is not propagated to the target servlet or server page.
 
 However, when a web component is invoked through the _RequestDispatcher_
 interface, any active transaction context must be propagated to the called
-servlet or server pages.
+servlet or server page.
 
 ==== Transactions in Web Component Life Cycles
 
@@ -183,18 +183,7 @@ the _service_ method thread, but should not be shared between threads.
 not be stored in static fields. Such objects can only be associated with one
 transaction at a time. Storing them in static fields would make it easy to
 erroneously share them between threads in different transactions.
-* Web components implementing
-_SingleThreadModel_ may store top-level transactional resource objects
-in class instance fields. A top-level object is one acquired directly
-from a container managed connection factory object (for example, a JDBC
-_Connection_ acquired from a JDBC _ConnectionFactory_ ), as opposed to
-other objects acquired from these top-level objects (for example, a JDBC
-_Statement_ acquired from a JDBC _Connection_ ). The web container
-ensures that requests to a _SingleThreadModel_ servlet are serialized
-and thus only one thread and one transaction will be able to use the
-object at a time, and that the top-level object will be enlisted in any
-new transaction started by the component.
-* In web components not implementing _SingleThreadModel_ , transactional
+* In web components, transactional
 resource objects, as well as Jakarta Persistence _EntityManager_ objects, should
 not be stored in class instance fields, and should be acquired and released
 within the same invocation of the _service_ method.
@@ -219,7 +208,7 @@ management support for application clients.
 ==== Transactional JDBC™ Technology Support
 
 A Jakarta EE product must support a JDBC technology database as a transactional
-resource manager. The platform must enable transactional JDBC API access from
+resource manager. The product must enable transactional JDBC API access from
 web components and enterprise beans.
 
 It must be possible to access the JDBC technology database from multiple
@@ -231,18 +220,18 @@ commit the transaction.
 A Jakarta EE product must provide a transaction manager that is capable of
 coordinating two-phase commit operations across multiple XA-capable JDBC
 databases. If a JDBC driver supports the Java SE API’s XA
-interfaces (in the _javax.transaction.xa_ package), then the Jakarta EE product
+interfaces (in the _javax.transaction.xa_ package), the Jakarta EE product
 must be capable of using the XA interfaces provided by the JDBC driver to
 accomplish two-phase commit operations. The Jakarta EE product may discover
 the XA capabilities of JDBC drivers through product-specific means, although
 normally such JDBC drivers would be delivered as resource adapters using the
-Connector API.
+Jakarta Connectors API.
 
 [[a520]]
 ==== Transactional Jakarta Messaging Support
 
 A Jakarta EE product must support a Jakarta Messaging provider as a
-transactional resource manager. The platform must enable transactional Jakarta
+transactional resource manager. The product must enable transactional Jakarta
 Messaging access from servlets, server pages, and enterprise beans.
 
 It must be possible to access the Jakarta Messaging provider from multiple
@@ -254,7 +243,7 @@ transaction, and, finally, commit the transaction.
 ==== Transactional Resource Adapter (Connector) Support
 
 A Jakarta EE product must support resource adapters that use _XATransaction_
-mode as transactional resource managers. The platform must enable transactional
+mode as transactional resource managers. The product must enable transactional
 access to the resource adapter from servlets, server pages, and enterprise
 beans.
 
@@ -266,7 +255,7 @@ finally, commit the transaction.
 
 === Transaction Interoperability
 
-==== Multiple Jakarta EE Platform Interoperability
+==== Multiple Jakarta EE Product Interoperability
 
 This specification does not require the Product Provider to implement any
 particular protocol for transaction interoperability across multiple Jakarta EE
@@ -282,7 +271,7 @@ interoperability protocol based on RMI-IIOP.
 ==== Support for Transactional Resource Managers
 
 This specification requires all Jakarta EE products to support the
-_javax.transaction.xa.XAResource_ interface, as referenced in the Connectors
+_javax.transaction.xa.XAResource_ interface, as referenced in the Jakarta Connectors
 specification. This specification also requires all Jakarta EE products to
 support the _javax.transaction.xa.XAResource_ interface for performing two-phase
 commit operations on JDBC drivers that support the Java SE XA APIs. This
@@ -350,14 +339,14 @@ When multiple connections acquired by a Jakarta EE application use the same
 resource manager, containers may choose to provide connection sharing within the
 same transaction scope. Sharing connections typically results in efficient usage
 of resources and better performance. Containers are required to provide
-connection sharing in certain situations; see the Connector specification for
+connection sharing in certain situations; see the Jakarta Connectors specification for
 details.
 
 Connections to resource managers acquired by Jakarta EE applications are
 considered potentially shared or shareable. A Jakarta EE application component
 that intends to use a connection in an unshareable way must provide deployment
-information to that effect, to prevent the connection from being shared by the
-container. Examples of when this may be needed include situations with changed
+information to that effect to prevent the connection from being shared by the
+container. Examples of when an unshared connection may be needed include situations with changed
 security attributes, isolation levels, character settings, and localization
 configuration. Containers must not attempt to share connections that are marked
 unshareable. If a connection is not marked unshareable, it must be transparent
@@ -375,7 +364,7 @@ Jakarta EE application components may cache connection objects and reuse them
 across multiple transactions. Containers that provide connection sharing must
 transparently switch such cached connection objects (at dispatch time) to point
 to an appropriate shared connection with the correct transaction scope. Refer
-to the Connector specification for a detailed description of connection
+to the Jakarta Connectors specification for a detailed description of connection
 sharing.
 
 === JDBC and Jakarta Messaging Deployment Issues
@@ -388,7 +377,7 @@ Messaging resources. Jakarta EE Product Providers may impose the restrictions
 described in this section to meet these requirements.
 
 If the deployer configures a non-XA-capable JDBC resource manager in a
-transaction, then a Jakarta EE Product Provider may restrict all JDBC access
+transaction, a Jakarta EE Product Provider may restrict all JDBC access
 within that transaction to that non-XA-capable JDBC resource manager. Otherwise,
 a Jakarta EE Product Provider must support use of multiple XA-capable JDBC
 resource managers within a transaction. In addition, a Jakarta EE Product
@@ -435,8 +424,8 @@ Although there are no compatibility requirements for system administration
 capabilities, the Jakarta EE Product Provider will typically include tools that
 allow the System Administrator to perform the following tasks:
 
-* Integrate transactional resource managers with the platform.
-* Configure the transaction management parts of the platform.
+* Integrate transactional resource managers with the product.
+* Configure the transaction management parts of the product.
 * Monitor transactions at runtime.
 * Receive notifications of abnormal transaction processing conditions (such as
 abnormally high number of transaction rollbacks).

--- a/specification/src/main/asciidoc/webprofile-spec.adoc
+++ b/specification/src/main/asciidoc/webprofile-spec.adoc
@@ -2,7 +2,7 @@
 // Copyright (c) 2017-2024 Contributors to the Eclipse Foundation
 //
 
-= Jakarta EE WebProfile
+= Jakarta EE Web Profile
 :authors: Jakarta EE Platform Team, https://projects.eclipse.org/projects/ee4j.jakartaee-platform
 :email: https://dev.eclipse.org/mailman/listinfo/jakartaee-platform-dev
 :version-label!:


### PR DESCRIPTION
- Prefix component spec names with Jakarta
- Change Connector spec name to Connectors
- Update application-client xsd to version 11
- Add Jakarta XML Registries to the removed list for EE 9
- Update Full Platform or Full Profile to just Platform
- Remove Enterprise Beans home usage from the specification
- Other small edits for punctuation or spelling errors