### PR TITLE
Specification updates

### DIFF
--- a/specification/src/main/asciidoc/platform/ApplicationAssemblyDeployment.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationAssemblyDeployment.adoc
@@ -18,7 +18,7 @@ flexibility and extensibility of the Jakarta EE component model facilitates
 the packaging and deployment of Jakarta EE components as individual
 components, component libraries, or Jakarta EE applications.
 
-A full Jakarta EE product must support all the
+A Jakarta EE Platform product must support all the
 facilities described in this chapter. A Jakarta EE profile may support only
 a subset of the Jakarta EE module types. Any requirements related to a
 module type not supported by a product based on a particular Jakarta EE
@@ -61,8 +61,8 @@ The Jakarta Enterprise Beans, Jakarta Servlet, application client, and
 Jakarta Connectors specifications include the XML Schema definition of the
 associated module level deployment descriptors and component packaging
 architecture required to produce Jakarta EE modules. (The application
-client specification is found in
-<<a3294, Application Clients chapter>> of this
+client specification is found in the
+<<a3294, Application Clients>> chapter of this
 document.)
 
 A Jakarta EE module is a collection of one or more
@@ -87,7 +87,7 @@ an application.
 * Starting with version 5 of the Java EE, a web application module, an enterprise bean module, or an
 application client module need not contain a deployment descriptor.
 Instead, the deployment information may be specified by annotations
-present in the class files of the module.
+present in the component class files in the module.
 * Starting with version 5 of the Java EE, a Jakarta EE enterprise application archive need not contain a
 deployment descriptor. Instead, the deployment information may be
 determined using default naming rules for embedded modules.
@@ -213,7 +213,7 @@ Every resource reference should be bound to a
 resource of the required type.
 
 Some resources have default mapping rules
-specified; see sections <<a2009, Default Data Source>>, <<a2025, Default JMS Connection Factory>>, and
+specified; see sections <<a2009, Default Data Source>>, <<a2025, Default Jakarta Messaging Connection Factory>>, and
 <<a2042, Default Concurrency Utilities Objects>>. By default, a product must map otherwise unmapped
 resources using these default rules. A product may include an option to
 disable or override these default mapping rules.
@@ -234,18 +234,14 @@ operational environment.
 [[a2945]]
 === Library Support
 
-The Jakarta EE provides several
+The Jakarta EE specification provides several
 mechanisms for applications to use optional packages and shared
 libraries (hereafter referred to as _libraries_ ). Libraries may be
 bundled with an application or may be installed separately for use by
 any application.
 
 Jakarta EE products are required to support the
-use of bundled and installed libraries as specified in the _Extension
-Mechanism Architecture_ and _Optional Package Versioning_ specifications
-(available at
-_https://docs.oracle.com/javase/8/docs/technotes/guides/extensions/_ )
-and the JAR File Specification (available at
+use of bundled and installed libraries as specified in the the JAR File Specification (available at
 _https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jar.html_ ).
 Using this mechanism a Jakarta EE JAR file can reference utility classes or
 other shared classes or resources packaged in a separate _.jar_ file or
@@ -312,55 +308,10 @@ These libraries may reference other libraries, either bundled with the
 application or installed separately, using any of the techniques
 described herein.
 
-==== Installed Libraries
-
-Libraries that have been installed separately
-may be referenced in the following way:
-
-. JAR format files of all types may contain
-an _Extension-List_ attribute in their Manifest file, indicating a
-dependency on an installed library. The JAR File Specification defines
-the semantics of such attributes; this specification
-requires support for such attributes for all component types and
-corresponding JAR format files. The deployment tool is required to check
-such dependency information and reject the deployment of any component
-for which the dependency can not be met. Portable applications should
-not assume that any installed libraries will be available to a component
-unless the component’s JAR format file, or one of the containing JAR
-format files, expresses a dependency on the library using the
-_Extension-List_ and related attributes.
-
-The referenced libraries must be made
-available to all components contained within the referencing file,
-including any components contained within other JAR format files within
-the referencing file. For example, if a _.ear_ file references an
-installed library, the library must be made available to all components
-in all _.war_ files, Jakarta Enterprise Beans _.jar_ files, application _.jar_ files, and
-resource adapter _.rar_ files within the _.ear_ file.
-
-A Jakarta EE product is not required to support
-downloading of libraries (using the _<extension>-Implementation-URL_
-header) at deployment time or runtime. A Jakarta EE product is also not
-required to support more than a single version of an installed library
-at once. A Jakarta EE product is not required to limit access to installed
-libraries to only those for which the application has expressed a
-dependency; the application may be given access to more installed
-libraries than it has requested. In all of these cases, such support is
-highly recommended and may be required in a future version of this
-specification. In particular, we recommend that a Jakarta EE product
-support multiple versions of an installed library, and by default only
-allow applications to access the installed libraries for which they have
-expressed a dependency.
-
 ==== Library Conflicts
 
 If an application includes a bundled version
-of a library, and the same library exists as an installed library, the
-instance of the library bundled with the application should be used in
-preference to any installed version of the library. This allows an
-application to bundle exactly the version of a library it requires
-without being influenced by any installed libraries. Note that if the
-library is also a required component of the Jakarta EE version on
+of a library and the same library is also a required component of the Jakarta EE version on
 which the application is being deployed, this version may (and
 typically will) take precedence.
 
@@ -369,10 +320,7 @@ typically will) take precedence.
 In addition to allowing access to referenced
 classes, as described above, any resources contained in the referenced
 JAR files must also be accessible using the _Class_ and _ClassLoader_
-_getResource_ methods, as allowed by the security permissions of the
-application. An application will typically have the security permissions
-required to access resources in any of the JAR files packaged with the
-application.
+_getResource_ methods.
 
 [[a2966]]
 ==== Dynamic Class Loading
@@ -387,44 +335,21 @@ by the library itself can safely use the _Class_ method _forName_ .
 However, libraries that need to dynamically load classes that have been
 provided as a part of the application need to use the context class
 loader to load the classes. Note that the context class loader may be
-different in each module of an application. Access to the context class
-loader requires _RuntimePermission_ (“ _getClassLoader”)_ , which is not
-normally granted to applications, but should be granted to libraries
-that need to dynamically load classes. Libraries can use a method such
-as the following to assert their privilege when accessing the context
-class loader. This technique will work in both Java SE and Jakarta EE.
-
+different in each module of an application. Libraries should use the following technique to load classes.
 
 [source,java]
 ----
-public ClassLoader getContextClassLoader() {
-  return AccessController.doPrivileged(
-    new PrivilegedAction<ClassLoader>() {
-      public ClassLoader run() {
-        ClassLoader cl = null;
-        try {
-          cl = Thread.currentThread().
+ClassLoader cl = Thread.currentThread().
                         getContextClassLoader();
-        } catch (SecurityException ex) { }
-        return cl;
-      }
-    });
-}
-----
-
-Libraries should then use the following technique to load classes.
-
-[source,java]
-----
-ClassLoader cl = getContextClassLoader();
 if (cl != null) {
   try {
     clazz = Class.forName(name, false, cl);
   } catch (ClassNotFoundException ex) {
     clazz = Class.forName(name);
   }
- } else
+} else
   clazz = Class.forName(name);
+}
 ----
 
 ==== Examples
@@ -481,29 +406,6 @@ app3.ear:
      WEB-INF/lib/jakartaservlet1.jar
 ----
 
-The following example illustrates a simple
-use of the installed library mechanism to reference a library of utility
-classes that is installed separately.
-
-----
-app1.ear:
-  META-INF/application.xml
-  ejb1.jar :
-    META-INF/MANIFEST.MF:
-      Extension-List: util
-      util-Extension-Name: com/example/util
-      util-Specification-Version: 1.4
-    META-INF/ejb-jar.xml
-
-util.jar:
-  META-INF/MANIFEST.MF:
-  Extension-Name: com/example/util
-  Specification-Title: example.com’s util package
-  Specification-Version: 1.4
-  Specification-Vendor: example.com
-  Implementation-Version: build96
-----
-
 [[a3040]]
 === Class Loading Requirements
 
@@ -522,16 +424,11 @@ if they need to load classes dynamically.
 
 In addition to the required classes specified
 below, a Jakarta EE product must provide a way to allow an application to
-access a class library installed in the application server, even if it
-has not expressed a dependency on that library. This supports the use of
-old applications and extension libraries that do not use the defined
-extension dependency mechanism.
+access a class library installed in the application server.
 
 The following sections describe the
 requirements for each container type. In all cases, access to classes is
 governed by the rules of the Java language and the Java virtual machine.
-In all cases, access to classes and resources is governed by the rules
-of the Java security model.
 
 Note that while libraries must be accessible
 to application classes as described below, it may be necessary to use
@@ -547,7 +444,7 @@ access to the following classes
 and resources. Note that as of Java EE 6, Java Enterprise Beans
 components may be packaged in a web component module. Such Java Enterprise Beans
 components have the same access as other components in the web
-container. See the Jakarta Enterprise Beans specification for further detail.
+container. See the Jakarta Enterprise Beans specification for further details.
 
 * The content of the _WEB-INF/classes_
 directory of the containing war file.
@@ -569,11 +466,6 @@ any resource adapter archives (rar files) included in the same ear file.
 each resource adapter archive (rar file) deployed separately to the
 application server, if that resource adapter is used to satisfy any
 resource references in the module.
-* The contents of all jar files included in
-each resource adapter archive (rar file) deployed separately to the
-application server, if any jar file in that rar file is used to satisfy
-any reference from the module using the Extension Mechanism Architecture
-(as specified in <<a2945, Library Support>>).
 * The transitive closure of any libraries
 referenced by the jar files in the rar files above (as specified in
 <<a2945, Library Support>>).
@@ -647,11 +539,6 @@ any resource adapter archives (rar files) included in the same ear file.
 each resource adapter archive (rar file) deployed separately to the
 application server, if that resource adapter is used to satisfy any
 resource references in the module.
-* The contents of all jar files included in
-each resource adapter archive (rar file) deployed separately to the
-application server, if any jar file in that rar file is used to satisfy
-any reference from the module using the Extension Mechanism Architecture
-(as specified in <<a2945, Library Support>>).
 * The transitive closure of any libraries
 referenced by the jar files in the rar files above (as specified in
 <<a2945, Library Support>>.
@@ -764,7 +651,7 @@ that are typically followed when composing a Jakarta EE application.
 . Select the Jakarta EE modules that will be used
 by the application.
 . Create an application directory structure.
-
++
 The directory structure of an application is
 arbitrary, but by following some simple conventions a deployment
 descriptor may not be needed. The structure should be designed around
@@ -772,7 +659,7 @@ the requirements of the contained components.
 
 . Reconcile Jakarta EE module deployment
 descriptors.
-
++
 The deployment descriptors for the Jakarta EE
 modules must be edited to link internally satisfied dependencies and
 eliminate any redundant security role names. An optional element
@@ -797,7 +684,7 @@ component dependency, there must only be one corresponding component
 that fulfills that dependency in the scope of the application.
 . For each _ejb-link_ , there must be only one
 matching _ejb-name_ in the scope of the entire application (see
-<<a936, Enterprise JavaBeans™ (EJB) References>>).
+<<a936, Jakarta Enterprise Beans References>>).
 . Dependencies that are not linked to internal
 components must be handled by the Deployer as external dependencies that
 must be met by resources previously installed on the platform. External
@@ -855,7 +742,7 @@ its own class namespace, and the classes from application clients are
 not visible in the class namespace of other components.
 . (Optional) Create an XML deployment
 descriptor for the application.
-
++
 The deployment descriptor must be named
 _application.xml_ and must reside in the top level of the _META-INF_
 directory of the application _.ear_ file. The deployment descriptor must
@@ -913,23 +800,21 @@ deployment units:
 * Stand-alone Jakarta EE modules.
 * Jakarta EE applications, consisting of one or
 more Jakarta EE modules.
-* Class libraries packaged as _.jar_ files
-according to the _Extension Mechanism Architecture_ . These class
-libraries then become installed libraries.
+* Class libraries packaged as _.jar_ files.
 
 Any Jakarta EE product must be able to accept a
 Jakarta EE application delivered as a _.ear_ file or a stand-alone Jakarta EE
 module delivered as a _.jar_ , _.war_ , or _.rar_ file (as appropriate
 to its type), together with an optional alternate deployment descriptor
-external to the application or standalone Jakarta EE module. If the
+external to the application or stand-alone Jakarta EE module. If the
 application is delivered as a _.ear_ , an enterprise bean module
 delivered as a _.jar_ file, a web application delivered as a _.war_
 file, or an application client delivered as a _.jar_ file, the
 deployment tool must be able to deploy the application such that the
 Jakarta classes in the application are in a separate namespace from classes
 in other Jakarta applications. Typically this will require the use of a
-separate class loader for each application. Standalone resource adapters
-delivered in _.rar_ files and standalone class libraries delivered in
+separate class loader for each application. Stand-alone resource adapters
+delivered in _.rar_ files and stand-alone class libraries delivered in
 _.jar_ files that become installed libraries will of necessity appear in
 the class namespaces of applications that use them, and may appear in
 the class namespace of any application depending on the level of
@@ -999,7 +884,7 @@ Deployer. The deployment tool may allow the Deployer to correct the
 error and continue deployment. Note that the deployment descriptor
 version refers only to the version of the XML schema or DTD against
 which the descriptor is to be validated. It does not provide any
-information as to what version of the Jakarta EE the application
+information as to what version of the Jakarta EE specification that the application
 is written to.
 
 Some deployment descriptors are optional. The
@@ -1075,7 +960,7 @@ provides the deployment information used in subsequent deployment steps.
 Note that there is no requirement for the merge process to produce a new
 deployment descriptor, although that might be a common implementation
 technique.
-. When deploying a standalone module, the
+. When deploying a stand-alone module, the
 module name is used as the application name. The deployment tool must
 ensure that the application name is unique in the application server
 instance. If the name is not unique, the deployment tool may
@@ -1090,9 +975,7 @@ component specification. If the module is a type that contains JAR
 format files (for example, web and connector modules), all classes in
 _.jar_ files within the module referenced from other JAR files within
 the module using the _Class-Path_ manifest header must be included in
-the deployment. If the module, or any JAR format files within the
-module, declares a dependency on an installed library, that dependency
-must be satisfied.
+the deployment.
 . The deployment tool must allow the Deployer
 to configure the container to provide the resources and configuration
 values needed for each component. The required resources and
@@ -1118,27 +1001,27 @@ _META-INF/application.xml_ ). If the deployment descriptor is present,
 it fully specifies the modules included in the application. If no
 deployment descriptor is present, the deployment tool uses the following
 rules to determine the modules included in the application.
-. All files in the application package with a
+* All files in the application package with a
 filename extension of _.war_ are considered web modules. The context
 root of the web module is the module name (see
 <<a2904, Component Creation>>).
-. All files in the application package with a
+* All files in the application package with a
 filename extension of _.rar_ are considered resource adapters.
-. A directory named _lib_ is considered to be
+* A directory named _lib_ is considered to be
 the library directory, as described in
 <<a2948, Bundled Libraries>>.
-. For all files in the application package
+* For all files in the application package
 with a filename extension of _.jar_ , but not contained in the _lib_
 directory, do the following:
-. If the _.jar_ file contains a
+** If the _.jar_ file contains a
 _META-INF/MANIFEST.MF_ file with a _Main-Class_ attribute, or contains a
 _META-INF/application-client.xml_ file, consider the .jar file to be an
 application client module.
-. If the _.jar_ file contains a
-_META-INF/ejb-jar.xml_ file, or contains any class with an Jakarta Enterprise Beans
+** If the _.jar_ file contains a
+_META-INF/ejb-jar.xml_ file, or contains any class with a Jakarta Enterprise Beans
 component-defining annotation ( _Stateless_ , etc.), consider the .jar
-file to be an Jakarta Enterprise Beans module.
-. All other _.jar_ files are ignored unless
+file to be a Jakarta Enterprise Beans module.
+** All other _.jar_ files are ignored unless
 referenced by a JAR file discovered above using one of the JAR file
 reference mechanisms such as the _Class-Path_ header in a manifest file.
 . The deployment tool must ensure that the
@@ -1184,9 +1067,7 @@ annotations and discovered as described in the previous requirement,
 into the appropriate container according to the deployment requirements
 of the respective Jakarta EE component specification. All classes in _.jar_
 files or directories referenced from other JAR files using the
-_Class-Path_ manifest header must be included in the deployment. If the
-_.ear_ file, or any JAR format files within the _.ear_ file, declares a
-dependency on an installed library, that dependency must be satisfied.
+_Class-Path_ manifest header must be included in the deployment.
 . The deployment tool must allow the Deployer
 to configure the container to provide the resources and configuration
 values needed for each component. The required resources and
@@ -1223,17 +1104,9 @@ error or other unspecified behavior.
 This section specifies the requirements for
 deploying a library.
 
-. The deployment tool must record the
-extension name and version information from the manifest file of the
-library JAR file. The deployment tool must make the library available to
-other Jakarta EE deployment units that request it according to the version
-matching rules described in the Optional Package Versioning
-specification. Note that the library itself may include dependencies on
+. The deployment tool must make the library available to
+other Jakarta EE deployment units that request it. Note that the library itself may include dependencies on
 other libraries and these dependencies must also be satisfied.
-. The deployment tool must make the library
-available with at least the same security permissions as any application
-or module that uses it. The library may be installed with the full
-security permissions of the container.
 . Not all libraries will be deployable on all
 Jakarta EE products at all times. Libraries that conflict with the
 operation of the Jakarta EE product may not be deployable. For example, an

--- a/specification/src/main/asciidoc/platform/ApplicationClients.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationClients.adoc
@@ -2,10 +2,10 @@
 == Application Clients
 :imagesdir: ../images
 
-This chapter describes application clients
-in the Jakarta™ Enterprise Edition (Jakarta EE).
+This chapter describes the requirements for application clients
+in Jakarta™ Enterprise Edition (Jakarta EE).
 
-A full Jakarta EE product must support the
+A Jakarta EE Platform product must support the
 application client container as described in this chapter. A Jakarta EE
 profile may or may not require support for the application client
 container.
@@ -61,7 +61,7 @@ authentication user interface instead.
 
 If a callback handler is configured by the
 Deployer, the application client container must instantiate an object of
-this class and use it for all authentication interactions with the user.
+this class name and use it for all authentication interactions with the user.
 The application’s callback handler must fully support _Callback_ objects
 specified in the _javax.security.auth.callback_ package.
 
@@ -103,7 +103,7 @@ method is called.
 Application clients have all the facilities of
 the Java™ Platform, Standard Edition (subject to security
 restrictions), as well as various standard extensions, as described in
-Chapter EE.6 “Application Programming Interface.” Each application
+<<a2133, Application Programming Interface>>. Each application
 client executes in its own Java virtual machine. Application clients
 start execution at the _main_ method of the class specified in the
 _Main-Class_ attribute in the manifest file of the application client’s
@@ -154,43 +154,11 @@ attribute.
 |N/A
 |No
 
-|application-client_5
+|application-client_5 or later
 |Yes
 |No
 
-|application-client_5
-|No
-|Yes
-
-|application-client_6
-|Yes
-|No
-
-|application-client_6
-|No
-|Yes
-
-|application-client_7
-|Yes
-|No
-
-|application-client_7
-|No
-|Yes
-
-|application-client_8
-|Yes
-|No
-
-|application-client_8
-|No
-|Yes
-
-|application-client_9
-|Yes
-|No
-
-|application-client_9
+|application-client_5 or later
 |No
 |Yes
 
@@ -247,14 +215,6 @@ _metadata-complete_ attribute applies currently includes the following:
 *  _jakarta.resource.AdministeredObjectDefinitions_
 *  _jakarta.resource.ConnectionFactoryDefinition_
 *  _jakarta.resource.ConnectionFactoryDefinitions_
-
-
-* All annotations in the following packages:
-** _jakarta.jws_
-** _jakarta.jws.soap_
-** _jakarta.xml.ws_
-** _jakarta.xml.ws.soap_
-** _jakarta.xml.ws.spi_
 
 If the _metadata-complete_ attribute is not
 specified or its value is _"false"_ , the deployment tool must examine

--- a/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
@@ -13,11 +13,11 @@ technologies.
 
 Jakarta EE application components execute in
 runtime environments provided by the containers that are a part of the
-Jakarta EE platform. The full Jakarta EE platform supports three types of
+Jakarta EE platform. The Jakarta EE platform supports three types of
 containers corresponding to Jakarta EE application component types:
 application client containers; web containers for
-servlets, Jakarta Server Pages, Jakarta Server Faces applications,
-Jakarta RESTful Web Services applications;
+servlets, server pages, server faces applications,
+RESTful web services applications;
 and enterprise bean containers. A Jakarta EE profile may support only a subset
 of these component types, as defined by the individual Jakarta EE profile
 specification.
@@ -34,7 +34,7 @@ apply.
 ==== Java Compatible APIs
 
 The containers provide all application
-components with at least the Java Platform, Standard Edition, v11 (Java
+components with at least the Java Platform, Standard Edition, v17 (Java
 SE) APIs. Containers may provide newer versions of the Java SE platform,
 provided they meet all the Jakarta EE platform requirements as outlined below.
 
@@ -49,22 +49,15 @@ provide these technologies in some other manner.
 
 The Java SE 17 platform includes the following enterprise technologies:
 
-* Java IDL footnote:[Removed from Java SE 11. Support for Java IDL is optional Product vendors that wish to support Java IDL on a Java SE version that does not provide the Java IDL APIs must otherwise provide those APIs to application components. ]
 * JDBC
 * RMI-JRMP
-* javax.rmi.PortableRemoteObject footnote:[Removed from Java SE 11. Product vendors that support the optional Enterprise Beans 2.x API group must ensure that the javax.rmi.PortableRemoteObject class is available to application components.]
 * JNDI
 * JAXP
 * StAX
 * JAAS
 * JMX
-* JAX-WS footnote:javaremovalopt[Removed from Java SE 11. Since Jakarta EE 9 this optional technology is provided under a Jakarta EE specification. If the technology is provided, the container must provide the Jakarta EE version of the technology. See <<a2161, Required Jakarta Technologies>>.]
-* JAXB footnote:javaremovalopt[]
-* JAF footnote:javaremovalreq[Removed from Java SE 11. Since Jakarta EE 9 this technology is provided under a Jakarta EE specification. The container must provide the Jakarta EE version of the technology. See <<a2161, Required Jakarta Technologies>>.]
-* SAAJ footnote:javaremovalopt[]
-* Common Annotations footnote:javaremovalreq[]
 
-Note that a number of the enterprise technologies provided
+Note that a number of the enterprise technologies that were previously provided
 by Java SE 8 are now provided by Jakarta EE specifications and are
 included in the list of <<a2161, Required Jakarta Technologies>>.
 
@@ -74,14 +67,14 @@ available at _https://docs.oracle.com/javase/17/docs/_ .
 ===== Java Module Names
 Java(TM) SE 9 introduced the concept of a modularity system, known as the Java Platform Module System (JPMS).
 Defined modules need a _name_ to allow for references by other modules.
-Jakarta EE 10 does not define a module naming convention.
+Jakarta EE 11 does not define a module naming convention.
 However, some Java EE(TM) 8 and Jakarta EE features had already defined their corresponding module names.
-Due to these previous module naming efforts, the following guidelines are strongly suggested for Jakarta EE 9:
+Due to these previous module naming efforts, the following guidelines are strongly suggested for Jakarta EE 11:
 
 * If an Automatic Module Name (MANIFEST) already exists, update the name to use the ‘jakarta’ prefix to be consistent with the package rename requirement.
-Do not create _new_ Automatic Module Names for Jakarta EE 9.  
+Do not create _new_ Automatic Module Names for Jakarta EE 11.  
 * If a module-info.class already exists, update the name to use the ‘jakarta’ prefix to be consistent with the package rename requirement.
-Do not create _new_ module-info.class files for Jakarta EE 9. 
+Do not create _new_ module-info.class files for Jakarta EE 11. 
 * If neither Automatic Module Names or module-info.class exists, then leave as-is.
 
 These guidelines allow existing module names to get to a consistent state with the least amount of disruption.
@@ -90,14 +83,14 @@ Any existing module names may need to be updated once specific module name requi
 [[a2161]]
 ==== Required Jakarta Technologies
 
-The full Jakarta EE platform also provides a
+The Jakarta EE platform also provides a
 number of technologies in each of the containers defined by this
 specification. <<a2159, Jakarta EE Technologies>> indicates the required technologies.
 Each Jakarta EE profile specification will include a similar table
 describing which technologies are required for the profile. Note that
 some technologies are marked Optional, as described in the next
-section.  Please see the table in the section Application Programming
-Interface for the specific versions required for each component.
+section. Jakarta EE 11 removed all optional specifications from the platform.
+Please see <<a3252, Jakarta™ EE Platform Product Requirements>> for the specific versions required for each component.
 
 *Note:* Jakarta EE 9 introduced the concept of "removed" technologies.
 This is the final stage of a technology's lifecycle where the technology is
@@ -205,6 +198,11 @@ technology will no longer be maintained for future versions of the Platform.
 |Y
 |Y
 
+|Pages
+|N
+|Y
+|N
+
 |Persistence
 |Y
 |Y
@@ -221,11 +219,6 @@ technology will no longer be maintained for future versions of the Platform.
 |Y
 
 |Server Faces
-|N
-|Y
-|N
-
-|Server Pages
 |N
 |Y
 |N
@@ -262,30 +255,29 @@ the specifications for the APIs must be provided by the Jakarta EE
 containers indicated above. In some cases, a Jakarta EE product is not
 required to provide objects that implement interfaces intended to be
 implemented by an application server, nevertheless, the definitions of
-such interfaces must be included in the Jakarta EE platform. If an
-implementation includes support for a technology marked as Optional,
-that technology must be supported in the containers specified above. If
-a product implementation does not support a technology marked as
-Optional, it must not include the APIs for that
+such interfaces must be included in the Jakarta EE product. If an
+implementation includes support for an optional or removed technology,
+that technology must be supported in the appropriate containers. If
+a product implementation does not support an optional or removed technology,
+it must not include the APIs for that
 technology.footnote:[Note that a component specification is permitted to specify
-an exception to this in order to accommodate interface type dependencies—for example,
-the Jakarta™ Enterprise Beans SessionContext dependency on the
-_jakarta.xml.rpc.handler.MessageContext_ type.]
-
-If a container supports Java SE 17 or a newer version of the Java SE platform, than all classes and interfaces provided by the container to satisfy the platform requirements listed above, must be compiled with the Java SE 17 source and class level.
+an exception to this in order to accommodate interface type dependencies]
 
 [[a2841]]
 ==== Platform Prospective Specifications
 
-During the development cycle for the current version of the Jakarta EE specification, the platform project considered several component specifications for inclusion in the platform. A consensus could not be reached on including these specifications in the platform. These specifications are considered as prospects for inclusion in a future version of the Platform specification.
+During the development cycle for the current version of the Jakarta EE specification, the platform 
+project considered several component specifications for inclusion in the platform. A consensus could 
+not be reached on including these specifications in the platform. These specifications are considered 
+as prospects for inclusion in a future version of the Platform specification.
 
 * https://jakarta.ee/specifications/mvc/[Jakarta MVC]
 
 [[a2331]]
 ==== Optional Jakarta Technologies
 
-As the Jakarta EE specification has evolved,
-some of the technologies originally included in Jakarta EE are no longer as
+As the Jakarta EE Platform specification has evolved,
+some of the technologies originally included in the Jakarta EE Platform are no longer as
 relevant as they were when they were introduced to the platform. The
 Jakarta EE Platform Specification Project follows a process similar to the one first defined by the Java SE
 expert group ( _https://mreinhold.org/blog/removing-features_ ) to stabilize and remove
@@ -293,7 +285,10 @@ technologies from the platform in a careful and orderly way that
 minimizes the impact to developers using these technologies, while
 allowing the platform to grow even stronger.
 
-An individual specification can have optional features. However when a component specification is included in the Platform, Web Profile, and Core Profile, an optional feature must be explicitly declared as required, otherwise it is not required. For complete normative details, see https://jakarta.ee/committees/specification/versioning/#allowedchanges[Jakarta EE Specification Versioning, Change, and Deprecation Process].
+An individual specification can have optional features. However when a component specification is included 
+in the Platform, Web Profile, and Core Profile, an optional feature must be explicitly declared as required, 
+otherwise it is not required. For complete normative details, see 
+https://jakarta.ee/committees/specification/versioning/#allowedchanges[Jakarta EE Specification Versioning, Change, and Deprecation Process].
 
 [[a2333]]
 ==== Removed Jakarta Technologies
@@ -319,9 +314,6 @@ The following Jakarta EE Technologies were removed from the Jakarta EE Platform.
 
 |Entity Beans, both Container and Bean Managed Persistence (Jakarta Enterprise Beans 4.0, Optional Features, Chapters 3 - 7)
 |Removed in Jakarta EE 10
-
-|Enterprise Web Services
-|Removed in Jakarta EE 11
 
 |SOAP with Attachments
 |Removed in Jakarta EE 11
@@ -377,9 +369,9 @@ The following URL protocols must be supported:
 need be supported. That is, the corresponding _URLConnection_ object’s
 _getOutputStream_ method may fail with an _UnknownServiceException_ .
 File access is restricted according to the permissions described above.
-*  _http_ _:_ Version 1.1 of the HTTP protocol
+*  _http_ _:_ Version 1.1 and 2.0 of the HTTP protocol
 must be supported. An _http_ URL must support both input and output.
-*  _https_ : SSL version 3.0 and TLS version 1.2
+*  _https_ : TLS version 1.2
 must be supported by _https_ URL objects. Both input and output must be
 supported.
 
@@ -488,13 +480,13 @@ server. Jakarta EE products are not required to support the application
 server facilities described by these APIs, although they may prove
 useful.
 
-The Connector architecture defines an SPI
+The Jakarta Connectors specification defines an SPI
 that essentially extends the functionality of the JDBC SPI with
 additional security functionality, and a full packaging and deployment
 functionality for resource adapters. A Jakarta EE product that supports the
-Connector architecture must support deploying and using a JDBC driver
+Jakarta Connectors specification must support deploying and using a JDBC driver
 that has been written and packaged as a resource adapter using the
-Connector architecture.
+Jakarta Connectors SPI.
 
 Every release of Jakarta EE declares a minimum required version of Java SE. For discussion, let this be Java SE N. Compatible implementations of Jakarta EE must support the latest version of the JDBC API mentioned in the Java SE N javadocs for the package `java.sql`. These javadocs typically have a link to the corresponding specification at `jcp.org`. 
 
@@ -538,9 +530,9 @@ A Jakarta EE product that supports the following
 types of objects must be able to make them available in the
 application’s JNDI namespace: _EJBHome_ objects, _EJBLocalHome_ objects,
 Enterprise Beans business interface objects, Jakarta Transactions _UserTransaction_ objects, JDBC API
-_DataSource_ objects, JMS _ConnectionFactory_ and _Destination_ objects,
+_DataSource_ objects, Jakarta Messaging _ConnectionFactory_ and _Destination_ objects,
 Jakarta Mail _Session_ objects, _URL_ objects, resource manager
-_ConnectionFactory_ objects (as specified in the Connector
+_ConnectionFactory_ objects (as specified in the Jakarta Connectors
 specification), _ORB_ objects, _EntityManagerFactory_ objects, and other
 Java language objects as described in
 <<a567, Resources, Naming, and Injection>>. The JNDI implementation in a Jakarta EE product must be
@@ -562,13 +554,13 @@ such objects must be in the JNDI _java:_ namespace. See
 Particular names are defined by this
 specification for the cases when the Jakarta EE product includes the
 corresponding technology. For all application components that have
-access to the Jakarta Transaction _UserTransaction_ interface, the appropriate
+access to the Jakarta Transactions _UserTransaction_ interface, the appropriate
 _UserTransaction_ object can be found using the name
 _java:comp/UserTransaction_ . In all containers, application components may lookup a CORBA _ORB_ instance
 using the name _java:comp/ORB_ . For all application components that
 have access to the CDI _BeanManager_ interface, the appropriate
 _BeanManager_ object can be found using the name _java:comp/BeanManager_
-. For all application components that have access to the Validation
+. For all application components that have access to the Jakarta Validation
 APIs, the appropriate _Validator_ and _ValidatorFactory_ objects can be
 found using the names _java:comp/Validator_ and
 _java:comp/ValidatorFactory_ respectively.
@@ -587,7 +579,7 @@ product to provide the necessary JNDI service providers for accessing
 the various objects defined in this specification.
 
 This specification requires that the Jakarta EE
-platform provide the ability to perform lookup operations as described
+product provide the ability to perform lookup operations as described
 above. Different JNDI service providers may provide different
 capabilities, for instance, some service providers may provide only
 read-only access to the data in the name service.
@@ -597,7 +589,7 @@ a COSNaming name service to meet the Jakarta Enterprise Beans interoperability
 requirements.  In such a case, a COSNaming JNDI service provider must be available
 through the web, Enterprise Beans, and application client containers.
 
-A COSNaming JNDI service provider is a part
+A COSNaming JNDI service provider was a part
 of the Java SE 8 SDK and JRE from Oracle, but is not a required
 component of the Java SE specification. The COSNaming JNDI service
 provider specification is available at
@@ -635,24 +627,13 @@ level application classes as described above. See
 <<a2966, Dynamic Class Loading>>
 for recommendations for libraries that dynamically load classes.
 
-===== Jakarta Authentication Requirements
-
-All enterprise beans containers and all web containers
-must support the use of the Jakarta Authentication APIs as specified in the Connector
-specification. All application client containers must support use of the
-Jakarta Authentication APIs.
-
-The Jakarta Authentication specification is
-available at _https://jakarta.ee/specifications/authentication/_ .
-
-
 ===== Logging API Requirements
 
 The Logging API provides classes and
 interfaces in the _java.util.logging_ package that are the Java™
 platform’s core logging facilities. This specification does not require
 any additional support for logging. A Jakarta EE application typically will
-not have the _LoggingPermission_ necessary to control the logging
+not control the logging
 configuration, but may use the logging API to produce log records. A
 future version of this specification may require that the Jakarta EE
 containers use the logging API to log certain events.
@@ -661,9 +642,7 @@ containers use the logging API to log certain events.
 
 The Preferences API in the _java.util.prefs_
 package allows applications to store and retrieve user and system
-preference and configuration data. A Jakarta EE application typically will
-not have the _RuntimePermission("preferences")_ necessary to use the
-Preferences API. This specification does not define any relationship
+preference and configuration data. This specification does not define any relationship
 between the principal used by a Jakarta EE application and the user
 preferences tree defined by the Preferences API. A future version of
 this specification may define the use of the Preferences API by Jakarta EE
@@ -690,9 +669,9 @@ access to local enterprise beans from the application client container.
 === Servlet 6.1 Requirements
 
 The Jakarta Servlet specification defines the
-packaging and deployment of web applications, whether standalone or as
+packaging and deployment of web applications, whether stand-alone or as
 part of a Jakarta EE application. The Servlet specification also addresses
-security, both standalone and within the Jakarta EE platform. These
+security, both stand-alone and within the Jakarta EE platform. These
 optional components of the Servlet specification are requirements of the
 Jakarta EE platform.
 
@@ -718,8 +697,7 @@ _putValue_ methods:
 *  _jakarta.transaction.UserTransaction_
 * a _javax.naming.Context_ object for the
 _java:comp/env_ context
-
-a reference to an Enterprise Bean local or remote business interface or no-interface view
+* a reference to an Enterprise Bean local or remote business interface or no-interface view
 
 Web containers may support objects of other
 types as well. Web containers must throw a
@@ -742,21 +720,21 @@ from the web container.
 The Jakarta Servlet specification is available at
 _https://jakarta.ee/specifications/servlet/_ .
 
-=== Server Pages 4.0 Requirements
+=== Pages 4.0 Requirements
 
-The Jakarta Server Pages specification depends on and builds
+The Jakarta Pages specification depends on and builds
 on the servlet framework. A Jakarta EE product must support the entire
-Jakarta Server Pages specification.
+Jakarta Pages specification.
 
-The Jakarta Server Pages specification is available at
+The Jakarta Pages specification is available at
 _https://jakarta.ee/specifications/pages/_ .
 
-=== Expression Language  (EL) 6.0 Requirements
+=== Expression Language (EL) 6.0 Requirements
 
 The Jakarta Expression Language specification was
-formerly a part of the Jakarta Server Pages specification. It was split off
+formerly a part of the Jakarta Pages specification. It was split off
 into its own specification so that it could be used independently of
-Jakarta Server Pages. A Jakarta EE product must support the Expression
+Jakarta Pages. A Jakarta EE product must support Jakarta Expression
 Language.
 
 The Jakarta Expression Language specification is
@@ -778,11 +756,10 @@ portable Jakarta EE applications must not use the following interfaces:
 *  _jakarta.jms.ServerSession_
 *  _jakarta.jms.ServerSessionPool_
 *  _jakarta.jms.ConnectionConsumer_
+* all _jakarta.jms_ XA interfaces
 
-all _jakarta.jms_ XA interfaces
-
-The following methods may only be used by
-application components executing in the application client container:
+Application components executing in the application client container
+may only use the following methods:
 
 *  _jakarta.jms.MessageConsumer_ method
 _getMessageListener_
@@ -818,13 +795,12 @@ _send(Destination_ _destination, Message_ _message,_ _int_
 _deliveryMode,_ _int_ _priority,_ _long_ _timeToLive,
 CompletionListener_ _completionListener)_
 
-The following methods may only be used by
-application components executing in the application client container.
+Application components executing in the application client container
+may only use the following methods.
 Note, however, that these methods provide an expert facility not used by
-ordinary applications. See the JMS specification for further detail.
+ordinary applications. See the Jakarta Messaging specification for further detail.
 
-_jakarta.jms.Session_ method _setMessageListener_
-
+*  _jakarta.jms.Session_ method _setMessageListener_
 *  _jakarta.jms.Session_ method
 _getMessageListener_
 *  _jakarta.jms.Session_ method _run_
@@ -834,8 +810,7 @@ _createConnectionConsumer_
 _createSharedConnectionConsumer_
 *  _jakarta.jms.Connection_ method
 _createDurableConnectionConsumer_
-
-_jakarta.jms.Connection_ method _createSharedDurableConnectionConsumer_
+*  _jakarta.jms.Connection_ method _createSharedDurableConnectionConsumer_
 
 A Jakarta EE container may throw a
 _JMSException_ (if allowed by the method) or a _JMSRuntimeException_ (if
@@ -856,22 +831,22 @@ on the same connection. Application client containers must support the
 creation of multiple sessions for each connection.
 
 The Jakarta Messaging specification defines further
-restrictions on the use of Jakarta Messaging in the Enterprise Beans and web containers. In
+restrictions on the use of Jakarta Messaging in the enterprise beans and web containers. In
 general, the behavior of a Jakarta Messaging provider should be the same in both the
 enterprise beans container and the web container.
 
 The Jakarta Messaging specification is available at
 _https://jakarta.ee/specifications/messaging/_ .
 
-=== Transaction 2.0 Requirements
+=== Transactions 2.0 Requirements
 
-Jakarta Transaction defines the _UserTransaction_ interface
+Jakarta Transactions defines the _UserTransaction_ interface
 that is used by applications to start, and commit or abort transactions.
 Application components get a _UserTransaction_ object through a JNDI
 lookup using the name _java:comp/UserTransaction_ or by requesting
 injection of a _UserTransaction_ object.
 
-Jakarta Transaction also defines the
+Jakarta Transactions also defines the
 _TransactionSynchronizationRegistry_ interface that can be used by
 system level components such as persistence managers to interact with
 the transaction manager. These components get a
@@ -879,14 +854,14 @@ _TransactionSynchronizationRegistry_ object through a JNDI lookup using
 the name _java:comp/TransactionSynchronizationRegistry_ or by requesting
 injection of a _TransactionSynchronizationRegistry_ object.
 
-A number of interfaces defined by Jakarta Transaction are used
+A number of interfaces defined by Jakarta Transactions are used
 by an application server to communicate with a transaction manager, and
 for a transaction manager to interact with a resource manager. These
-interfaces must be supported as described in the Connector
+interfaces must be supported as described in the Jakarta Connectors
 specification. In addition, support for other transaction facilities may
 be provided transparently to the application by a Jakarta EE product.
 
-The Jakarta Transaction specification is available at
+The Jakarta Transactions specification is available at
 _https://jakarta.ee/specifications/transactions/_ .
 
 === Activation 2.1 Requirements
@@ -894,31 +869,31 @@ _https://jakarta.ee/specifications/transactions/_ .
 Jakarta Activation defines a set of standard services to: determine the MIME
 type of an arbitrary piece of data; encapsulate access to it; discover the operations
 available on it; and instantiate the appropriate bean to perform the operation(s).
-A Jakarta EE product must support Activation.
+A Jakarta EE product must support Jakarta Activation.
 
 The Jakarta Activation specification is available at
 _https://jakarta.ee/specifications/activation/_ .
 
 === Mail 2.1 Requirements
 
-The Jakarta Mail API allows for access to email
+Jakarta Mail allows for access to email
 messages contained in message stores, and for the creation and sending
 of email messages using a message transport. Specific support is
 included for Internet standard MIME messages. Access to message stores
 and transports is through protocol providers supporting specific store
-and transport protocols. The Jakarta Mail API specification does not require
+and transport protocols. The Jakarta Mail specification does not require
 any specific protocol providers, but the Jakarta EE platform
 should include an IMAP message store provider, a POP3 message
 store provider, and an SMTP message transport provider.
 
-Configuration of the Jakarta Mail API is
+Configuration of Jakarta Mail is
 typically done by setting properties in a _Properties_ object that is
 used to create a _jakarta.mail.Session_ object using a static factory
 method. To allow the Jakarta EE platform to configure and manage Jakarta Mail
-API sessions, an application component that uses the Jakarta Mail API should
+sessions, an application component that uses the Jakarta Mail API should
 request a _Session_ object using JNDI, and should list its need for a
 _Session_ object in its deployment descriptor using a _resource-ref_
-element, or by using a _Resource_ annotation. A Jakarta Mail API _Session_
+element, or by using a _Resource_ annotation. A Jakarta Mail _Session_
 object should be considered a resource factory, as described in
 <<a1120, Resource Manager Connection Factory References>>. This specification requires that the
 Jakarta EE platform support _jakarta.mail.Session_ objects as resource
@@ -940,7 +915,7 @@ EE product support any message store protocols.
 Note that the Jakarta Mail API creates threads to
 deliver notifications of _Store_ , _Folder_ , and _Transport_ events.
 The use of these notification facilities may be limited by the
-restrictions on the use of threads in various containers. In Enterprise Beans
+restrictions on the use of threads in various containers. In enterprise beans
 containers, for instance, it is typically not possible to create
 threads.
 
@@ -960,7 +935,7 @@ indicated in <<a2675, Jakarta Mail API MIME Data Type to Java Type Mappings>> .
 |text/plain
 |java.lang.String
 
-|text/html_
+|text/html
 |java.lang.String
 
 |text/xml
@@ -973,16 +948,17 @@ indicated in <<a2675, Jakarta Mail API MIME Data Type to Java Type Mappings>> .
 |jakarta.mail.internet.MimeMessage
 |===
 
-The Jakarta Mail API specification is available
+The Jakarta Mail specification is available
 at _https://jakarta.ee/specifications/mail/_ .
 
 === Connectors 2.1 Requirements
 
-In full Jakarta EE products, all Jakarta Enterprise Beans containers
-and all web containers must support the full set of Connector APIs. All
+In Jakarta EE products that implement the platform specification, 
+all enterprise beans containers
+and all web containers must support the full set of Jakarta Connectors APIs. All
 such containers must support Resource Adapters that use any of the
 specified transaction capabilities. The Jakarta EE deployment tools must
-support deployment of Resource Adapters, as defined in the Connector
+support deployment of Resource Adapters, as defined in the Jakarta Connectors
 specification, and must support the deployment of applications that use
 Resource Adapters.
 
@@ -995,7 +971,7 @@ Jakarta RESTful Web Services defines APIs for the development of
 Web services built according to the Representational State Transfer
 (REST) architectural style.
 
-In a full Jakarta EE product, all Jakarta EE web
+In a Jakarta EE product, all Jakarta EE web
 containers are required to support applications that use Jakarta RESTful Web Services
 technology.
 
@@ -1013,56 +989,56 @@ be made available.
 The Jakarta RESTful Web Services specification is available at
 _https://jakarta.ee/specifications/restful-ws/_ .
 
-=== WebSocket 2.2 (WebSocket) Requirements
+=== WebSocket 2.2 Requirements
 
-The Jakarta WebSocket (WebSocket) is a
-standard API for creating WebSocket applications. In a full Jakarta EE
+Jakarta WebSocket is a
+standard API for creating WebSocket applications. In a Jakarta EE
 product, all Jakarta EE web containers are required to support the
 WebSocket API.
 
 The Jakarta WebSocket specification can
 be found at _https://jakarta.ee/specifications/websocket/_ .
 
-=== JSON Processing 2.1 (JSON-P) Requirements
+=== JSON Processing (JSON-P) 2.1 Requirements
 
 JSON (JavaScript Object Notation) is a
-lightweight data-interchange format used by many web services. The
+lightweight data-interchange format used by many web services.
 Jakarta JSON Processing (JSON-P) provides a convenient way to process
 (parse, generate, transform, and query) JSON text.
 
-In a full Jakarta EE product, all Jakarta EE
+In a Jakarta EE product, all Jakarta EE
 application client containers, web containers, and enterprise beans containers are
-required to support the JSON-P API.
+required to support the Jakarta JSON Processing API.
 
 The Jakarta JSON Processing
 specification can be found at _https://jakarta.ee/specifications/jsonp/_ .
 
 [[a2713]]
 
-=== JSON Binding 3.0 (JSON-B) Requirements
+=== JSON Binding (JSON-B) 3.0 Requirements
 
-The Jakarta JSON Binding API for JSON Binding (JSON-B)
+The Jakarta JSON Binding (JSON-B) API
 provides a convenient way to map between JSON text and Java objects.
 
-In a full Jakarta EE product, all Jakarta EE
+In a Jakarta EE product, all Jakarta EE
 application client containers, web containers, and enterprise beans containers are
-required to support the JSON-B API.
+required to support the Jakarta JSON Binding API.
 
 The Jakarta JSON Binding  specification
 can be found at _https://jakarta.ee/specifications/jsonb/_.
 
-=== Concurrency 3.1 (Concurrency Utilities) Requirements
+=== Concurrency 3.1 Requirements
 
-Jakarta Concurrency Utilities for Jakarta EE is a
+Jakarta Concurrency is a
 standard API for providing asynchronous capabilities to Jakarta EE
 application components through the following types of objects: managed
 executor service, managed scheduled executor service, managed thread
-factory, and context service. In a full Jakarta EE product, all web
-containers and enterprise beans containers are required to support the Concurrency
-Utilities API. The Jakarta EE Product Provider must provide preconfigured
+factory, and context service. In a Jakarta EE product, all web
+containers and enterprise beans containers are required to support the Jakarta Concurrency
+API. The Jakarta EE Product Provider must provide pre-configured
 default managed executor service, managed scheduled executor service,
 managed thread factory, and context service objects for use by the
-application in the containers in which the Concurrency Utilities API is
+application in the containers in which the Jakarta Concurrency API is
 required to be supported.
 
 The Jakarta Concurrency
@@ -1070,11 +1046,11 @@ specification can be found at _https://jakarta.ee/specifications/concurrency/_ .
 
 === Batch 2.1 Specification Requirements
 
-The Jakarta Batch provides a programming model for batch
+Jakarta Batch provides a programming model for batch
 applications and a runtime for scheduling and executing jobs.
 
-In a full Jakarta EE product, all Jakarta EE web
-containers and Jakarta Enterprise Beans containers are required to support the Batch API.
+In a Jakarta EE product, all Jakarta EE web
+containers and enterprise beans containers are required to support the Batch API.
 
 The Jakarta Batch specification can be found
 at _https://jakarta.ee/specifications/batch/_ .
@@ -1083,7 +1059,7 @@ at _https://jakarta.ee/specifications/batch/_ .
 
 The Jakarta Authorization specification defines a contract
 between a Jakarta EE application server and an authorization policy
-provider. In a full Jakarta EE product, all Jakarta EE web containers and
+provider. In a Jakarta EE product, all Jakarta EE web containers and
 enterprise bean containers are required to support this contract.
 
 The Jakarta Authorization specification can be found at
@@ -1104,13 +1080,12 @@ authenticated by the message sender. They authenticate incoming messages
 and return to their calling container the identity established as a
 result of the message authentication.
 
-In a full Jakarta EE product, all Jakarta EE web
+In a Jakarta EE product, all Jakarta EE web
 containers and enterprise bean containers are required to support the
 baseline compatibility requirements as defined by the Jakarta Authentication
-specification. In a full Jakarta EE product, all web containers must also
-support the Servlet Container Profile as defined in the Jakarta Authentication
-specification. In a Jakarta EE profile product that includes Servlet and
-Jakarta Authentication, all web containers must also support the Servlet Container
+specification. All enterprise beans containers and all web containers
+must support the use of the Jakarta Authentication APIs as specified in the Jakarta Connectors
+specification. All web containers must also support the Servlet Container
 Profile as defined in the Jakarta Authentication specification.
 Support for the Jakarta Authentication SOAP Profile is not required.
 
@@ -1120,38 +1095,38 @@ _https://jakarta.ee/specifications/authentication/_ .
 [[a2741]]
 === Security 4.0 Requirements
 
-Jakarta Security leverages Jakarta Authentication ,
+Jakarta Security leverages Jakarta Authentication,
 but provides an easier to use SPI for authentication of users of web
 applications and defines identity store APIs for authentication and
 authorization.
 
-In a full Jakarta EE product, all Jakarta EE web
+In a Jakarta EE product, all Jakarta EE web
 containers and enterprise bean containers are required to support the
 requirements defined by the Jakarta Security specification.
 
 The Jakarta Security Specification can be
 found at _https://jakarta.ee/specifications/security/_ .
 
-=== Debugging Support for Other Languages Requirements 2.0
+=== Debugging Support for Other Languages 2.0 Requirements
 
-Jakarta Server Pages pages are usually translated into Java
+Server pages are usually translated into Java
 language pages and then compiled to create class files. The Jakarta Debugging Support for Other Languages
 specification describes information that can
 be included in a class file to relate class file data to data in the
 original source file. All Jakarta EE products are required to be able to
 include such information in class files that are generated from
-Jakarta Server Pages.
+server pages.
 
 The Jakarta Debugging Support for Other Languages
 specification can be found at _https://jakarta.ee/specifications/debugging/_ .
 
-=== Standard Tag Library for Jakarta Server Pages 3.0 Requirements
+=== Standard Tag Library 3.0 Requirements
 
-Jakarta Standard Tag Library specification defines a standard tag library that
-makes it easier to develop Jakarta Server Pages. All Jakarta EE products are required
-to provide a Jakarta Standard Tag Library for use by all Jakarta Server Pages.
+The Jakarta Standard Tag Library specification defines a standard tag library that
+makes it easier to develop server pages. A Jakarta EE product must support
+Jakarta Standard Tag Library specification for use by all server pages.
 
-The Jakarta Standard Tag Library for Jakarta Server Pages
+The Jakarta Standard Tag Library
 specification can be found at _https://jakarta.ee/specifications/tags/_ .
 
 === Server Faces 4.1 Requirements
@@ -1161,7 +1136,7 @@ building user interfaces for Jakarta applications. Developers of
 various skill levels can quickly build web applications by: assembling
 reusable UI components in a page; connecting these components to an
 application data source; and wiring client-generated events to
-server-side event handlers. In a full Jakarta EE product, all Jakarta EE web
+server-side event handlers. In a Jakarta EE product, all Jakarta EE web
 containers are required to support applications that use the Jakarta Server
 Faces technology.
 
@@ -1331,9 +1306,9 @@ both web tier and business tier technologies.
 The CDI specification can be found at
 _https://jakarta.ee/specifications/cdi/_ .
 
-=== Dependency Injection for Java 2.0 Requirements
+=== Dependency Injection 2.0 Requirements
 
-The Dependency Injection for Java (DI)
+The Dependency Injection
 specification defines a standard set of annotations (and one interface)
 for use on injectable classes.
 
@@ -1341,8 +1316,16 @@ In the Jakarta EE platform, support for
 Dependency Injection is mediated by CDI. See
 <<a2112, Support for Dependency Injection>> for more detail.
 
-The DI specification can be found at
+The Dependency Injection specification can be found at
 _https://jakarta.ee/specifications/dependency-injection/_ .
+
+=== Data 1.0 Requirements
+
+The Jakarta Data specification provides an API for easier data access. A Java developer can split the persistence 
+from the model with several features, such as the ability to compose custom query methods on a Repository interface.
+A Jakarta EE product must support Jakarta Data.
+
+The Data specification can be found at _https://jakarta.ee/specifications/data/_ .
 
 // generates a line between text and footnotes for pdf and html generation.
 '''

--- a/specification/src/main/asciidoc/platform/CompatibilityMigration.adoc
+++ b/specification/src/main/asciidoc/platform/CompatibilityMigration.adoc
@@ -30,10 +30,10 @@ applications written to a previous version of the platform will continue
 to work without change and with identical behavior on the current
 version of the platform.
 
+[[a3901]]
 ==== Backwards Compatibility for Jakarta EE 11
 
 ===== Removed Technologies
-* Jakarta Enterprise Web Services
 * Jakarta Managed Beans
 * Jakarta SOAP with Attachments
 * Jakarta XML Binding
@@ -45,8 +45,8 @@ ManagedBean annotation should transition to another bean defining annotation suc
 
 Support for Jakarta XML Web Services, along with the Jakarta XML Binding and the SOAP with attachments
 specifications, was made optional with the Jakarta EE 10 release, and is now removed
-from the Jakarta EE 11 platform.  Jakarta EE platform products can continue to support the XML Web Services specifications
-to work with the Jakarta EE 11 platform just like other standalone specifications that are not part of the platform.
+from the Jakarta EE 11 platform.  Jakarta EE products can continue to support these technologies
+to work with the Jakarta EE 11 platform just like other stand-alone specifications that are not part of the platform.
 
 ==== Backwards Compatibility for Jakarta EE 10
 
@@ -54,7 +54,6 @@ to work with the Jakarta EE 11 platform just like other standalone specification
 * Entity Beans, both Container and Bean Managed Persistence (Jakarta Enterprise Beans 4.0, Optional Features, Chapters 3 - 7)
 * Embeddable EJB Container (Jakarta Enterprise Beans, Core Features 4.0, Chapter 17)
 
-[[a3901]]
 ==== Backwards Compatibility for Jakarta EE 9
 Due to the migration from the `javax` namespace to the `jakarta` namespace, Jakarta
 EE 9 is not source-code compatible or binary compatible with previous releases.
@@ -129,19 +128,23 @@ modeling capabilities and object/relational mapping capabilities than
 EJB CMP entity beans and is significantly easier to use.
 
 Support for EJB CMP and BMP entity beans has
-been made optional with the Java EE 7 release. Support for EJB CMP 1.1
+been optional since the Java EE 7 release. Support for EJB CMP 1.1
 entity beans has been optional since Java EE 5. Applications are
-strongly encouraged to migrate applications using EJB entity beans to
+strongly encouraged to migrate applications using entity beans to
 Jakarta Persistence.
 
-==== Jakarta XML Web Services (optional)
+==== Jakarta XML Web Services
 
-Jakarta XML Web Services, along with the Jakarta XML Binding and the Metadata for
-Web Services specifications, provides simpler and more complete support
+Jakarta XML Web Services, along with the Jakarta XML Binding and the SOAP with
+attachments specifications, provides simpler and more complete support
 for web services than is available using the older JAX-RPC technology. Support
-for JAX-RPC was made optional with the Java EE 7 release, and is now removed
+for JAX-RPC was made optional with the Java EE 7 release, and was removed
 from the Jakarta EE 9 platform.
 Applications that provide web services using JAX-RPC should consider
 migrating to the Jakarta XML Web Services API. Note that because both technologies support
 the same web service interoperability standards, clients and services
 can be migrated to the new API independently.
+
+Jakarta XML and SOAP technologies have been removed from the Jakarta EE Platform with
+the Jakarta EE 11 release.  Application using XML and SOAP technologies should consider
+using the RESTful Web Services API for their web services.

--- a/specification/src/main/asciidoc/platform/Interoperability.adoc
+++ b/specification/src/main/asciidoc/platform/Interoperability.adoc
@@ -20,7 +20,7 @@ of applications:
 and Visual Basic.
 * applications running on a personal computer
 platform, or Unix® workstation.
-* standalone Java™ technology-based applications
+* stand-alone Java™ technology-based applications
 that are not directly supported by the Jakarta EE platform.
 
 It is the interoperability features of the
@@ -79,7 +79,7 @@ underlying operating system. A Jakarta EE web container must be capable of
 advertising its HTTP services on the standard HTTP port, port 80.
 * HTTP/2—Server-side support for the HTTP/2
 protocol is required by the Servlet specification.
-* SSL 3.0, TLS 1.2—SSL 3.0 (Secure Socket Layer)
+* TLS 1.2—TLS 1.2 (Transport Layer Security)
 represents the security layer for Web communication. It is available
 indirectly when using the _https_ URL as opposed to the _http_ URL. A
 Jakarta EE web container must be capable of advertising its HTTPS service
@@ -87,15 +87,15 @@ on the standard HTTPS port, port 443.
 * SOAP 1.1—SOAP is a presentation layer
 protocol for the exchange of XML messages. Support for SOAP layered on
 HTTP is optional, as described in the Jakarta XML-based RPCfootnote:removed9[Removed in Jakarta EE 9] and 
-Jakarta XML Web Servicesfootnote:optional9[Made optional in Jakarta EE 9] specifications.
+Jakarta XML Web Servicesfootnote:removed11[Removed in Jakarta EE 11] specifications.
 * SOAP 1.2—SOAP 1.2 is the version of the SOAP
-protocol standardized through W3C and supported by Jakarta XML Web Servicesfootnote:optional9[].
+protocol standardized through W3C and supported by Jakarta XML Web Servicesfootnote:removed11[].
 * WS-I Basic Profile 1.1—The WS-I Basic
 Profile, in combination with the Simple SOAP Binding Profile and
 Attachment Profile, describes interoperability requirements for the use
 of SOAP 1.1, WSDL 1.1, and MIME-based SOAP with Attachments. It is
 optional as defined by the Jakarta XML-based RPCfootnote:removed9[] and 
-Jakarta XML Web Servicesfootnote:optional9[] specifications.
+Jakarta XML Web Servicesfootnote:removed11[] specifications.
 * WebSocket protocol—The WebSocket protocol
 enables two-way communication layered over TCP. It enables
 bi-directional communication over a single connection established by an
@@ -105,7 +105,7 @@ been standardized by IETF under RFC 6455.
 [[a2875]]
 ==== OMG Protocols (optional)
 
-Support for the Object Management Group (OMG) based protocols is optional for Jakarta EE 9.
+Support for the Object Management Group (OMG) based protocols was made optional in Jakarta EE 9.
 
 ==== Java Technology Protocols
 
@@ -130,7 +130,7 @@ _https://docs.oracle.com/javase/8/docs/technotes/guides/rmi/_ .
 
 In addition to the protocols that allow
 communication between components, this specification requires Jakarta EE
-platform support for a number of data formats. These formats provide the
+products to support a number of data formats. These formats provide the
 definition for data exchanged between components.
 
 The following data formats must be supported:
@@ -144,7 +144,7 @@ format commonly used to transfer structured data between a server and
 web application. The Jakarta JSON Processing API provides support for the parsing,
 generation, transformation, and querying of JSON text. The Jakarta JSON Binding API
 provides support for mapping between JSON text and Java objects.
-* HTML 4.01—This represents the minimum web
+* HTML 4.01—This version represents the minimum web
 browser standard document format. While all Jakarta EE APIs with the
 exception of Jakarta Server Faces are agnostic to the version of the browser document
 format, Jakarta EE web clients must be able to display HTML 4.01 documents.

--- a/specification/src/main/asciidoc/platform/PlatformOverview.adoc
+++ b/specification/src/main/asciidoc/platform/PlatformOverview.adoc
@@ -133,7 +133,7 @@ are an application’s user interface. They may also be used to generate
 XML or other format data that is consumed by other application
 components. A special kind of servlet may provide support for web services
 using the SOAP/HTTP protocol. Servlets, pages created with the
-Jakarta Server Pages technology or Jakarta Server Faces technology, web
+Jakarta Pages technology or Jakarta Server Faces technology, web
 filters, and web event listeners are referred to collectively in this
 specification as “web components.” Web applications are composed of web
 components and other data such as HTML pages. Web components execute in
@@ -248,7 +248,7 @@ these standard services are actually provided by Java SE.
 
 The HTTP client-side API is defined by the _java.net_ package. The
 HTTP server-side API is defined and used by the Jakarta RESTful Web Services,
-Jakarta Servlet, Jakarta Server Pages, and Jakarta Server Faces
+Jakarta Servlet, Jakarta Pages, and Jakarta Server Faces
 interfaces and by Jakarta XML Web Services support that is no longer a required part of
 the Jakarta EE platform.
 
@@ -257,7 +257,7 @@ the Jakarta EE platform.
 Use of the HTTP protocol over the SSL protocol
 is supported by the same client and server APIs as HTTP.
 
-==== Jakarta Transaction API (JTA)
+==== Jakarta Transactions API
 
 The Jakarta Transactions consists of two parts:
 
@@ -275,7 +275,7 @@ application-level interface used by the application components to access
 a database, and a service provider interface to attach a JDBC driver to
 the Jakarta EE platform. Support for the service provider interface is not
 required in Jakarta EE products. Instead, JDBC drivers should be packaged
-as resource adapters that use the facilities of the Connector API to
+as resource adapters that use the facilities of the Jakarta Connectors API to
 interface with a Jakarta EE product. The JDBC API is included in Java SE,
 but this specification includes additional requirements on JDBC device
 drivers.
@@ -407,7 +407,7 @@ APIs for authentication and authorization.
 
 ==== XML Web Services
 
-Jakarta Enterprise Web Services, Jakarta XML Web Services, XML
+Jakarta XML Web Services, XML
 Binding and SOAP with Attachments have been removed from the Platform
 as of Jakarta EE 11. See <<a2333, Removed Jakarta Technologies>>.
 
@@ -550,8 +550,8 @@ This specification describes a minimum set of
 facilities available to all Jakarta EE products. A Jakarta EE profile may
 include some or all of these facilities, as described in
 <<a3212, Profiles>>. Products
-implementing the full Jakarta EE platform must provide all of them (see
-<<a3252, Full Jakarta EE Product Requirements>>). 
+implementing the Jakarta EE platform must provide all of them (see
+<<a3252, Jakarta EE Platform Product Requirements>>). 
 Most Jakarta EE products will provide facilities beyond
 the minimum required by this specification. This specification includes
 only a few limits to the ability of a product to provide extensions. In
@@ -667,7 +667,7 @@ may customize the business logic of the application’s components at
 deployment time. For example, using tools provided with a Jakarta EE
 product, the Deployer may provide simple application code that wraps an
 enterprise bean’s business methods, or customizes the appearance of a
-Jakarta Server Pages or Jakarta Server Faces page.
+server pages or server faces page.
 
 The Deployer’s output is web applications,
 enterprise beans, and application clients that have been
@@ -718,7 +718,7 @@ provider as defined by the Jakarta Authorization specification.
 === Platform Contracts
 
 This section describes the Jakarta EE contracts that must be fulfilled by a Jakarta EE Product
-Provider implementing the full Jakarta EE platform. Jakarta EE profiles may
+Provider implementing the Jakarta EE platform. Jakarta EE profiles may
 include some or all of these facilities, as described in
 <<a3212, Profiles>>.
 
@@ -1022,4 +1022,4 @@ Jakarta EE 10 also introduced a new Core Profile to support smaller runtime foot
 === Changes in Jakarta EE 11
 The goal of the Jakarta EE 11 release is to deliver a set of specifications that and adding the support for the Java SE 17 and newer runtimes. The TCKs require support for both Java SE 17 and Java SE 21.
 
-Jakarta EE 11 removes Managed Beans, Enterprise Web Services, XML Web Services, XML Binding and SOAP with Attachments from the platform and introduces the new Jakarta Data specification to the platform.
+Jakarta EE 11 removes Managed Beans, SOAP with Attachments, XML Binding and XML Web Services from the platform and introduces the new Jakarta Data specification to the platform.

--- a/specification/src/main/asciidoc/platform/PlatformOverview.adoc
+++ b/specification/src/main/asciidoc/platform/PlatformOverview.adoc
@@ -1022,4 +1022,20 @@ Jakarta EE 10 also introduced a new Core Profile to support smaller runtime foot
 === Changes in Jakarta EE 11
 The goal of the Jakarta EE 11 release is to deliver a set of specifications that and adding the support for the Java SE 17 and newer runtimes. The TCKs require support for both Java SE 17 and Java SE 21.
 
-Jakarta EE 11 removes Managed Beans, SOAP with Attachments, XML Binding and XML Web Services from the platform and introduces the new Jakarta Data specification to the platform.
+Jakarta EE 11 removes the following technologies from the platform.
+
+* Managed Beans
+* SOAP with Attachments
+* XML Binding
+* XML Web Services
+
+Because the minimum Java SE version is 17, technologies that have been removed from Java SE as of version 17 have also been removed from the Jakarta EE platform. Such technologies include but are not limited to the following.
+
+* Security Manager
+* Extension Mechanism Architecture and Optional Package Versioning requirements
+
+Jakarta EE 11 adds the following technology to the platform.
+
+* Jakarta Data
+
+

--- a/specification/src/main/asciidoc/platform/Profiles.adoc
+++ b/specification/src/main/asciidoc/platform/Profiles.adoc
@@ -138,7 +138,7 @@ requirements.
 [[a3240]]
 === Requirements for All Jakarta EE Profiles
 
-The Java Platform, Standard Edition 11 is the
+The Java Platform, Standard Edition 17 is the
 required API compilation level for any Jakarta EE profile.
 
 The following technologies are required to be
@@ -163,10 +163,10 @@ optional for use in Jakarta EE profiles:
 <<a1385, ORB References>>)
 
 [[a3252]]
-=== Full Jakarta™ EE Product Requirements
+=== Jakarta™ EE Platform Product Requirements
 
 This section defines the requirements for
-full Jakarta EE platform products. These requirements correspond to the
+Jakarta EE platform products. These requirements correspond to the
 full set of requirements in previous versions of the Jakarta EE platform
 specification and update those requirements for this new version of the
 platform.
@@ -199,12 +199,12 @@ The following technologies are required:
 * Jakarta JSON Binding 3.0
 * Jakarta Mail 2.1
 * Jakarta Messaging 3.1
+* Jakarta Pages 4.0*
 * Jakarta Persistence 3.2*
 * Jakarta RESTful Web Services 4.0*
 * Jakarta Security 4.0*
 * Jakarta Servlet 6.1*
 * Jakarta Server Faces 4.1*
-* Jakarta Server Pages 4.0*
 * Jakarta Standard Tag Library 3.0
 * Jakarta Transactions 2.0
 * Jakarta Validation 3.1*
@@ -219,11 +219,10 @@ The following technologies are removed:
 
 * Jakarta Enterprise Beans 2.x API group
 * Jakarta Enterprise Beans 3.2 and earlier entity beans and associated Jakarta Enterprise Beans QL
-* Jakarta Enterprise Web Services
 * Jakarta Managed Beans
 * Jakarta SOAP with Attachments
 * Jakarta XML Binding
 * Jakarta XML Web Services
 
 Besides the Jakarta Managed Beans specification, Jakarta EE platform products can continue to support the removed specifications
-just like any other standalone specification that is not part of the platform.
+just like any other stand-alone specification that is not part of the platform.

--- a/specification/src/main/asciidoc/platform/RelatedDocuments.adoc
+++ b/specification/src/main/asciidoc/platform/RelatedDocuments.adoc
@@ -30,7 +30,7 @@ _Java™ Naming and Directory Interface 1.2 Specification (JNDI specification)_.
 
 _Jakarta™ Messaging Specification, Version 3.1_. Available at: _https://jakarta.ee/specifications/messaging/3.1/_
 
-_Jakarta™ Transaction Specification, Version 2.0_. Available at: _https://jakarta.ee/specifications/transactions/2.0/_
+_Jakarta™ Transactions Specification, Version 2.0_. Available at: _https://jakarta.ee/specifications/transactions/2.0/_
 
 _Jakarta™ Mail Specification, Version 2.1_. Available at: _https://jakarta.ee/specifications/mail/2.1/_
 
@@ -62,7 +62,6 @@ _Jakarta™ Validation Specification, Version 3.1_. Available at: _https://jakar
 
 _Jakarta™ Interceptors Specification, Version 2.2_. Available at: _https://jakarta.ee/specifications/interceptors/2.2/_
 
-[[cdi-spec]]
 _Jakarta™ Contexts and Dependency Injection Specification, Version 4.1_. Available at: _https://jakarta.ee/specifications/cdi/4.1/_
 
 _Jakarta™ Dependency Injection Specification, Version 2.0_. Available at: _https://jakarta.ee/specifications/dependency-injection/2.0/_
@@ -80,12 +79,6 @@ _Jakarta™ Batch Specification, Version 2.1_. Available at: _https://jakarta.ee
 _Jakarta™ Data Specification, Version 1.0_. Available at: _https://jakarta.ee/specifications/data/1.0/_
 
 _Jakarta EE Specification Process (JESP), Version 1.4_. Available at: _https://jakarta.ee/about/jesp/_
-
-Extension Mechanism Architecture, Available at
-_https://docs.oracle.com/javase/8/docs/technotes/guides/extensions/index.html_
-
-Optional Package Versioning, Available at
-_https://docs.oracle.com/javase/8/docs/technotes/guides/extensions/index.html_
 
 JAR File Specification, Available at
 _https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jar.html_

--- a/specification/src/main/asciidoc/platform/ResourcesNamingInjection.adoc
+++ b/specification/src/main/asciidoc/platform/ResourcesNamingInjection.adoc
@@ -116,10 +116,10 @@ component’s environment.
 * <<a1863, Mail Session Definition>> describes the use by eligible application
 components of references to Jakarta Mail _Session_ resources in the component’s
 environment.
-* <<a1917, Connector Connection Factory Definition>> describes the use by eligible
+* <<a1917, Jakarta Connectors Connection Factory Definition>> describes the use by eligible
 application components of references to Jakarta Connectors connection factory
 resources in the component’s environment.
-* <<a1967, Connector Administered Object Definition>> describes the use by
+* <<a1967, Jakarta Connectors Administered Object Definition>> describes the use by
 eligible application components of references to Jakarta Connectors administered
 object resources in the component’s environment.
 * <<a2009, Default Data Source>> describes the use by eligible application
@@ -227,7 +227,7 @@ in a single enterprise bean module, or all components in a web module).
 *  _java:app_ – Names in this namespace are
 shared by all components in all modules in a single application, where
 “single application” means a single deployment unit, such as a single
-ear file, a single module deployed standalone, etc. For example, a war
+ear file, a single module deployed stand-alone, etc. For example, a war
 file and a Jakarta Enterprise Beans jar file in the same ear file would both have access to
 resources in the _java:app_ namespace.
 *  _java:global_ – Names in this namespace are
@@ -450,6 +450,15 @@ be put into service.
 |Classes supporting injection
 |Support level
 
+|Jakarta Pages
+|tag handlers
+
+tag library event listeners
+
+|Standard
+
+Standard
+
 |Jakarta Servlet
 |servlets
 
@@ -464,15 +473,6 @@ HTTP upgrade handlers
 Standard
 
 Standard
-
-Standard
-
-|Jakarta Server Pages
-|tag handlers
-
-tag library event listeners
-
-|Standard
 
 Standard
 
@@ -3340,7 +3340,7 @@ values have not been specified.
 The following requirements apply to the
 resource definitions described in Sections
 <<a1688, DataSource Resource Definition>> through 
-<<a1967, Connector Administered Object Definition>>.
+<<a1967, Jakarta Connectors Administered Object Definition>>.
 
 When an Application Component Provider or
 Application Assembler specifies connectivity information to a “physical”
@@ -3867,7 +3867,7 @@ definition types are described in
 <<a1676, Requirements Common to All Resource Definition Types>>.
 
 [[a1917]]
-==== Connector Connection Factory Definition
+==== Jakarta Connectors Connection Factory Definition
 
 An application may define Jakarta Connectors
 connection factory resources.
@@ -3964,7 +3964,7 @@ definition types are described in
 <<a1676, Requirements Common to All Resource Definition Types>>.
 
 [[a1967]]
-==== Connector Administered Object Definition
+==== Jakarta Connectors Administered Object Definition
 
 An application may define a Jakarta Connectors
 administered object resource. The administered object resource may be
@@ -4237,7 +4237,7 @@ Provider's default database.
 
 The Jakarta EE Platform requires that a Jakarta EE
 Product Provider provide a Jakarta Messaging provider in the operational environment
-(see <<a104, Jakarta™ Message Service (Jakarta Messaging)>>).
+(see <<a104, Jakarta™ Messaging>>).
 The Jakarta EE Product Provider must also provide a
 preconfigured, Jakarta Messaging ConnectionFactory for use by the application in
 accessing this Jakarta Messaging provider.
@@ -4334,16 +4334,16 @@ ManagedExecutorService myManagedExecutorService;
 
 The Jakarta EE Product Provider must provide the following:
 
-* a preconfigured, default managed executor service for use by the application in accessing this service under the JNDI name _java:comp/DefaultManagedExecutorService_ ;
+* a preconfigured, default managed executor service for use by the application in accessing this service under the JNDI name _java:comp/DefaultManagedExecutorService_
 * a preconfigured, default managed scheduled
 executor service for use by the application in accessing this service
-under the JNDI name _java:comp/DefaultManagedScheduledExecutorService_ ;
+under the JNDI name _java:comp/DefaultManagedScheduledExecutorService_
 * a preconfigured, default managed thread
 factory for use by the application in accessing this factory under the
-JNDI name _java:comp/DefaultManagedThreadFactory_ ;
+JNDI name _java:comp/DefaultManagedThreadFactory_
 * a preconfigured, default context service
 for use by the application in accessing this service under the JNDI name
-_java:comp/DefaultContextService_.
+_java:comp/DefaultContextService_
 
 If a Jakarta Concurrency object resource
 environment reference is not mapped to a specific configured object by
@@ -4472,7 +4472,7 @@ environment reference.
 
 The Application Component Provider is
 responsible for requesting injection of a _BeanManager_ instance using a
-_Resource_ annotation, or using the defined name to look up an instance
+_Resource_ or _Inject_ annotation, or using the defined name to look up an instance
 in JNDI.
 
 ==== Jakarta EE Product Provider’s Responsibilities
@@ -4503,8 +4503,8 @@ conditions will be eligible for full dependency injection support as
 described in the CDI specification.
 
 Component classes listed in
-<<a651, Component classes supporting injection>> that satisfy the third condition above, but
-neither the first nor the second condition, can also be used as CDI
+<<a651, Component classes supporting injection>> that satisfy the second condition above, but
+not the first condition, can also be used as CDI
 managed beans if they are annotated with a CDI bean-defining annotation
 or contained in a bean archive for which CDI is enabled. However, if
 they are used as CDI managed beans (e.g., injected into other managed

--- a/specification/src/main/asciidoc/platform/RevisionHistory.adoc
+++ b/specification/src/main/asciidoc/platform/RevisionHistory.adoc
@@ -3,10 +3,12 @@
 == Revision History
 === Changes in Final Release for Jakarta EE 11
 * Updated Java SE base version to 17.
-* Removed requirement for SOAP with Attachments, XML Binding, Enterprise Web Services and XML Web Services.
+* Removed requirement for SOAP with Attachments, XML Binding and XML Web Services.
 * Removed references to the Applet Container.
 * Removed requirements related to the Java SecurityManager. 
 * Updated <<relateddocs, “Related Documents">> for the updated Specifications in Jakarta EE 11.
+* Add "Component Specification Integration Requirements" chapter mostly coming from the CDI specification.
+* Add "Concurrency Resource Definitions" section to the "Resources, Naming, and Injection" chapter.
 
 === Changes in Final Release for Jakarta EE 10
 * Updated Java SE base version to 11.

--- a/specification/src/main/asciidoc/platform/Security.adoc
+++ b/specification/src/main/asciidoc/platform/Security.adoc
@@ -57,7 +57,7 @@ mentioned in <<a457, Future Directions>>.
 
 The security behavior of a Jakarta EE environment
 may be better understood by examining what happens in a simple
-application with a web client, a server pages user interface, and enterprise bean
+application with a web client, a Jakarta Pages user interface, and enterprise bean
 business logic. (The example is not meant to specify requirements.)
 
 In this example, the web client relies on the

--- a/specification/src/main/asciidoc/platform/Security.adoc
+++ b/specification/src/main/asciidoc/platform/Security.adoc
@@ -57,7 +57,7 @@ mentioned in <<a457, Future Directions>>.
 
 The security behavior of a Jakarta EE environment
 may be better understood by examining what happens in a simple
-application with a web client, a Jakarta Pages user interface, and enterprise bean
+application with a web client, a server pages user interface, and enterprise bean
 business logic. (The example is not meant to specify requirements.)
 
 In this example, the web client relies on the
@@ -734,7 +734,7 @@ _SecurityContext_ method _getCallerPrincipal_ can also be called in the
 Jakarta Enterprise Beans container, and still returns _null_ for anonymous users.
 
 In Jakarta EE products that contain both a web
-container and an Jakarta Enterprise Beans container, components running in a web container
+container and a Jakarta Enterprise Beans container, components running in a web container
 must be able to call enterprise beans even when no user has been
 authenticated in the web container. When a call is made in such a case
 from a component in a web container to an enterprise bean, a Jakarta EE
@@ -869,7 +869,7 @@ Servlet specifications.
 
 ==== Propagated Caller Identities.
 
-In a Jakarta EE product that contains an Jakarta Enterprise Beans
+In a Jakarta EE product that contains a Jakarta Enterprise Beans
 container, it must be possible to configure the Jakarta EE product so that
 a propagated caller identity is used in all authorization decisions.
 With this configuration, for all calls to all enterprise beans from a
@@ -915,7 +915,7 @@ and the access control context.
 
 All Jakarta EE products must implement the access
 control semantics described in all included component specifications,
-such as the Jakarta Enterprise Beans, Jakarta Server Pages, and
+such as the Jakarta Enterprise Beans, Jakarta Pages, and
 Jakarta Servlet specifications; provide a means of
 mapping the security roles specified in metadata annotations or the
 deployment descriptor to the actual roles exposed by a Jakarta EE product;

--- a/specification/src/main/asciidoc/platform/ServiceProviderInterface.adoc
+++ b/specification/src/main/asciidoc/platform/ServiceProviderInterface.adoc
@@ -9,14 +9,14 @@ include some or all of these facilities, as described in <<a3212, Profiles>>.
 
 === Jakarta™ Connectors
 
-The Connector API defines how resource adapters
+The Jakarta Connectors specification defines how resource adapters
 are packaged and integrated with any Jakarta EE product. Many types of
-service providers can be provided using the Connector API and packaging,
-including JDBC drivers, Jakarta Messaging providers, and Jakarta XML Registries
-providers. All Jakarta EE products must support the Connector APIs, as specified
+service providers can be provided using the Jakarta Connectors API and packaging,
+including JDBC drivers and Jakarta Messaging providers. 
+All Jakarta EE products must support the Jakarta Connectors APIs, as specified
 in the Jakarta Connectors specification.
 
-The Jakarta EE Connectors specification is available at
+The Jakarta Connectors specification is available at
 _https://jakarta.ee/specifications/connectors/_ .
 
 === Jakarta™ Authorization
@@ -29,17 +29,17 @@ _https://jakarta.ee/specifications/authorization/_ .
 
 === Jakarta™ Transactions
 
-The Jakarta Transactions defines the
+The Jakarta Transactions specification defines the
 _TransactionSynchronizationRegistry_ interface that is intended for use
 by system level application server components such as persistence
 managers, resource adapters, as well as Jakarta Enterprise Beans and Web application
-components. This provides the ability to register synchronization
+components. This interface provides the ability to register synchronization
 objects with special ordering semantics, associate resource objects with
 the current transaction, get the transaction context of the current
 transaction, get current transaction status, and mark the current
 transaction for rollback.
 
-The Jakarta Transaction specification is available at
+The Jakarta Transactions specification is available at
 _https://jakarta.ee/specifications/transactions/_ .
 
 === Jakarta™ Persistence

--- a/specification/src/main/asciidoc/platform/SpecificationComparison.adoc
+++ b/specification/src/main/asciidoc/platform/SpecificationComparison.adoc
@@ -48,7 +48,7 @@ It is important to understand that despite any name or version changes, Java EE 
 |Jakarta™ Messaging 2.0
 
 |Java™ Transaction API 1.2
-|Jakarta™ Transaction 1.3
+|Jakarta™ Transactions 1.3
 
 |JavaMail™ API 1.6
 |Jakarta™ Mail 1.6
@@ -118,7 +118,7 @@ It is important to understand that despite any name or version changes, Java EE 
 
 To address cleanly separating the `javax.transaction` package in Java™ SE from the classes being contributed, a Maintenance Release of the Java™ Transaction API (JTA) was created in the JCP and released as https://jcp.org/aboutJava/communityprocess/maintenance/jsr907/JTA1.3MR-November2017.pdf[version 1.3].  The official Jakarta version is therefore 1.3 and not 1.2.
 
-No API changes were made in this Maintenance Release or after contribution and Java™ Transaction API 1.2, Java™ Transaction API 1.3 and Jakarta Transaction 1.3 are functionally equivalent.
+No API changes were made in this Maintenance Release or after contribution and Java™ Transaction API 1.2, Java™ Transaction API 1.3 and Jakarta Transactions 1.3 are functionally equivalent.
 
 ==== Deployment 1.2 vs 1.7
 

--- a/specification/src/main/asciidoc/platform/cdi-ee-spec/javaeeintegration.adoc
+++ b/specification/src/main/asciidoc/platform/cdi-ee-spec/javaeeintegration.adoc
@@ -2,8 +2,8 @@
 :cdi_full: CDI Full
 :cdi_lite: CDI Lite
 --
-This part of the document specifies additional rules or features when using CDI in a Jakarta EE container.
-All content defined in the {cdi-spec}[CDI specification] applies to this part.
+This section specifies additional rules or features when using CDI in a Jakarta EE container.
+All requirements defined in the {cdi-spec}[CDI specification] also apply to this section.
 
 CDI implementations in Jakarta EE containers are required to support {cdi_full}.
 --

--- a/specification/src/main/asciidoc/platform/cdi-ee-spec/javaeeintegration.adoc
+++ b/specification/src/main/asciidoc/platform/cdi-ee-spec/javaeeintegration.adoc
@@ -1,8 +1,9 @@
+:cdi-spec: https://jakarta.ee/specifications/cdi/4.1/
 :cdi_full: CDI Full
 :cdi_lite: CDI Lite
 --
 This part of the document specifies additional rules or features when using CDI in a Jakarta EE container.
-All content defined in <<cdi-spec>> applies to this part.
+All content defined in the {cdi-spec}[CDI specification] applies to this part.
 
 CDI implementations in Jakarta EE containers are required to support {cdi_full}.
 --

--- a/specification/src/main/asciidoc/platform/cdi-ee-spec/xrefs.adoc
+++ b/specification/src/main/asciidoc/platform/cdi-ee-spec/xrefs.adoc
@@ -176,3 +176,9 @@ References from the CDI EE Integration specification to the online CDI core spec
 
 [[process_bean_attributes]]
 * {cdi_spec_url}#process_bean_attributes[3.9.5.9. ProcessBeanAttributes event]
+
+[[declaring_selected_alternatives_application]]
+* {cdi_spec_url}#declaring_selected_alternatives_application[5.1.1.1. Declaring selected alternatives for an application]
+
+[[declaring_selected_alternatives_bean_archive]]
+* {cdi_spec_url}#declaring_selected_alternatives_bean_archive[16.1.1.2. Declaring selected alternatives for a bean archive]

--- a/specification/src/main/asciidoc/webprofile/Introduction.adoc
+++ b/specification/src/main/asciidoc/webprofile/Introduction.adoc
@@ -48,7 +48,7 @@ a middle ground between these two sets of requirements.
 
 In terms of completeness, the Web Profile
 offers a complete stack, with technologies addressing presentation and
-state management (Jakarta Server Faces, Jakarta Pages), core web
+state management (Jakarta Faces, Jakarta Pages), core web
 container funtionality (Jakarta Servlet), business logic (Jakarta Enterprise Beans
 Lite), transactions (Jakarta Transactions), persistence (Jakarta
 Persistence) and more.

--- a/specification/src/main/asciidoc/webprofile/Introduction.adoc
+++ b/specification/src/main/asciidoc/webprofile/Introduction.adoc
@@ -48,7 +48,7 @@ a middle ground between these two sets of requirements.
 
 In terms of completeness, the Web Profile
 offers a complete stack, with technologies addressing presentation and
-state management (Jakarta Server Faces, Jakarta Server Pages), core web
+state management (Jakarta Server Faces, Jakarta Pages), core web
 container funtionality (Jakarta Servlet), business logic (Jakarta Enterprise Beans
 Lite), transactions (Jakarta Transactions), persistence (Jakarta
 Persistence) and more.
@@ -126,7 +126,7 @@ specification.
 Particular care should be taken when
 determining applicable requirements based on the presence of Jakarta Enterprise Beans Lite in
 the Web Profile. As described in the Jakarta Enterprise Beans specification, Jakarta Enterprise Beans Lite is a
-subset of the Jakarta Enterprise Beans API. When examining an Jakarta Enterprise Beans-related requirement in the
+subset of the Jakarta Enterprise Beans API. When examining a Jakarta Enterprise Beans-related requirement in the
 Jakarta EE Platform spec, one must first of all determine which API
 classes, component types and Jakarta Enterprise Beans container services are mentioned in the
 requirement itself. Only if all of them fall inside the Jakarta Enterprise Beans Lite subset

--- a/specification/src/main/asciidoc/webprofile/RelatedDocuments.adoc
+++ b/specification/src/main/asciidoc/webprofile/RelatedDocuments.adoc
@@ -22,7 +22,7 @@ _Jakarta™ Expression Language Specification, Version 6.0_. Available at: _http
 
 _Jakarta™ Servlet Specification, Version 6.1_. Available at: _https://jakarta.ee/specifications/servlet/6.1/_
 
-_Jakarta™ Transaction Specification, Version 2.0_. Available at: _https://jakarta.ee/specifications/transactions/2.0/_
+_Jakarta™ Transactions Specification, Version 2.0_. Available at: _https://jakarta.ee/specifications/transactions/2.0/_
 
 _Jakarta™ RESTful Web Services Specification, Version 4.0_. Available at: _https://jakarta.ee/specifications/restful-ws/4.0/_
 

--- a/specification/src/main/asciidoc/webprofile/WebProfileDefinition.adoc
+++ b/specification/src/main/asciidoc/webprofile/WebProfileDefinition.adoc
@@ -20,11 +20,11 @@ The following technologies are required components of the Web Profile:
 * Jakarta Interceptors 2.2*
 * Jakarta JSON Binding 3.0
 * Jakarta JSON Processing 2.1
+* Jakarta Pages 4.0*
 * Jakarta Persistence 3.2*
 * Jakarta RESTful Web Services 4.0*
 * Jakarta Security 4.0*
 * Jakarta Server Faces 4.1*
-* Jakarta Server Pages 4.0*
 * Jakarta Servlet 6.1*
 * Jakarta Standard Tag Library 3.0
 * Jakarta Transactions 2.0
@@ -39,7 +39,7 @@ There are no optional components in the Web
 Profile.
 
 Web Profile products may support some of the
-technologies present in the full Jakarta EE Platform and not already listed
+technologies present in the Jakarta EE Platform and not already listed
 in <<a43, Required Components>>,
 consistently with their compatibility requirements.
 

--- a/specification/src/main/asciidoc/webprofile/jpa-cdi/CDI-JPA.adoc
+++ b/specification/src/main/asciidoc/webprofile/jpa-cdi/CDI-JPA.adoc
@@ -1,5 +1,5 @@
-:cdi-spec: https://jakarta.ee/specifications/cdi/4.1
-:jpa-spec: https://jakarta.ee/specifications/persistence/3.2/jakarta-persistence-spec-3.2
+:cdi-spec: https://jakarta.ee/specifications/cdi/4.1/
+:jpa-spec: https://jakarta.ee/specifications/persistence/3.2/
 :platform-profile: https://jakarta.ee/specifications/platform/11/
 [[a441]]
 === Jakarta Persistence & Jakarta Context and Dependency Injection (CDI) Integration


### PR DESCRIPTION
- Just say Jakarta EE product or Jakarta EE platform without the word full before it.
- Update to use the Jakarta component specification names instead of the Java EE names
- Remove Extension Mechanism Architecture and Optional Package Versioning requirements from installed libraries section
- Clean up Java security manager and permission references
- Combine the two Jakarta Authentication Requirements sections
- Other cleanup for spelling, unresolved links, consistency, maintainability, correct formatting and removing of old technologies references