### PR TITLE
Platform and Profile spec updates

### DIFF
--- a/specification/src/main/asciidoc/images/JakartaEEarchitecture.svg
+++ b/specification/src/main/asciidoc/images/JakartaEEarchitecture.svg
@@ -289,24 +289,6 @@
       <g
          id="g3932"
          style="stroke-width:0.595461">
-        <rect
-           y="263.56372"
-           x="434.57999"
-           height="16.35257"
-           width="32.705139"
-           id="rect3923"
-           style="color:#000000;overflow:visible;fill:#4d4d4d;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.19092;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-        <text
-           id="text3927"
-           y="275.46329"
-           x="471.51404"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:10.5833px;line-height:125%;font-family:sans-serif;-inkscape-font-specification:sans-serif;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.157549px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:sans-serif;-inkscape-font-specification:sans-serif;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.157549px"
-             y="275.46329"
-             x="471.51404"
-             id="tspan3925"
-             sodipodi:role="line">Optional in Jakarta EE 9</tspan></text>
         <path
            style="stroke:none;stroke-width:3.40263"
            d=""
@@ -502,10 +484,6 @@
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.168552px"
            id="tspan4330">SSL</tspan></text>
     </g>
-    <path
-       style="fill:#bdbfbc;fill-opacity:1;stroke:#000000;stroke-width:14.2988;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m -1053.8629,2344.1369 v -60.4745 h 130.64318 130.64315 v 60.4745 60.4746 h -130.64315 -130.64318 z"
-       id="path1293" />
     <rect
        y="-1871.3733"
        x="-2127.5825"
@@ -556,9 +534,9 @@
        transform="scale(1.0009154,0.99908543)"><tspan
          sodipodi:role="line"
          id="tspan1390"
-         x="-259.95792"
+         x="-109.95792"
          y="-1729.4202"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:86.5093px;font-family:sans-serif;-inkscape-font-specification:sans-serif;fill:#000000;fill-opacity:1;stroke-width:5.00456;stroke-miterlimit:4;stroke-dasharray:none">Server Pages</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:86.5093px;font-family:sans-serif;-inkscape-font-specification:sans-serif;fill:#000000;fill-opacity:1;stroke-width:5.00456;stroke-miterlimit:4;stroke-dasharray:none">Pages</tspan></text>
     <path
        sodipodi:nodetypes="cccccc"
        d="m 1414.5185,-1807.4803 v 230.5037 H 897.28547 v -230.5037 l 250.38833,-69.419 z"
@@ -616,75 +594,6 @@
     <g
        transform="matrix(5.0092536,0,0,4.9998642,-324.07196,-1058.2444)"
        id="g2341">
-      <g
-         style="stroke-width:0.849424"
-         id="g1507"
-         transform="rotate(90,358.55265,-281.58092)">
-        <path
-           id="use5061-6-0"
-           style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 703.01523,-331.57671 v -17.48916 H 563.1663 v 17.48916 z"
-           sodipodi:nodetypes="cccc"
-           inkscape:tile-x0="-59.591586"
-           inkscape:tile-y0="-744.37067" />
-        <text
-           id="text1502"
-           y="-336.7551"
-           x="579.51715"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;stroke-width:0.264583"
-           xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;stroke-width:0.264583"
-             y="-336.7551"
-             x="579.51715"
-             id="tspan1500"
-             sodipodi:role="line">Enterprise Beans</tspan></text>
-      </g>
-      <g
-         style="stroke-width:0.849424"
-         id="g1507-0"
-         transform="rotate(90,349.80807,-290.3255)">
-        <g
-           id="g1536"
-           transform="translate(-4.24302)">
-          <path
-             id="use5061-6-0-1"
-             style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-             d="m 707.25825,-331.57671 v -17.48916 H 567.40932 v 17.48916 z"
-             sodipodi:nodetypes="cccc"
-             inkscape:tile-x0="-59.591586"
-             inkscape:tile-y0="-744.37067" />
-          <text
-             id="text1502-5"
-             y="-337.0376"
-             x="570.47589"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;stroke-width:0.264583"
-             xml:space="preserve"><tspan
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;stroke-width:0.264583"
-               y="-337.0376"
-               x="570.47589"
-               id="tspan1500-3"
-               sodipodi:role="line">Expression Language</tspan></text>
-        </g>
-      </g>
-      <path
-         inkscape:tile-y0="-744.37067"
-         inkscape:tile-x0="-59.591586"
-         sodipodi:nodetypes="cccc"
-         d="m 373.57012,62.881658 h 17.48916 v -139.84893 h -17.48916 z"
-         style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="use5061-6-0-1-1" />
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583"
-         x="-7.0885887"
-         y="-379.03101"
-         id="text1502-5-1"
-         transform="rotate(90)"><tspan
-           sodipodi:role="line"
-           id="tspan1500-3-9"
-           x="-7.0885887"
-           y="-379.03101"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Messaging</tspan></text>
       <path
          id="use5061-6-0-9"
          style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -703,7 +612,7 @@
            y="-360.34555"
            x="-7.0428123"
            id="tspan1500-7"
-           sodipodi:role="line">Transactions</tspan></text>
+           sodipodi:role="line">Enterprise Beans</tspan></text>
       <path
          inkscape:tile-y0="-744.37067"
          inkscape:tile-x0="-59.591586"
@@ -722,7 +631,7 @@
            id="tspan1500-3-8"
            x="-7.2015038"
            y="-342.85638"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Activation</tspan></text>
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Expression Language</tspan></text>
       <path
          id="use5061-6-0-1-1-5"
          style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -741,7 +650,7 @@
            y="-325.1933"
            x="-7.0763817"
            id="tspan1500-3-9-6"
-           sodipodi:role="line">Mail</tspan></text>
+           sodipodi:role="line">Messaging</tspan></text>
       <path
          id="use5061-6-0-3"
          style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -760,7 +669,7 @@
            y="-307.8262"
            x="-7.7447166"
            id="tspan1500-4"
-           sodipodi:role="line">Connectors</tspan></text>
+           sodipodi:role="line">Transactions</tspan></text>
       <path
          inkscape:tile-y0="-744.37067"
          inkscape:tile-x0="-59.591586"
@@ -779,7 +688,7 @@
            id="tspan1500-3-88"
            x="-8.2635155"
            y="-290.18445"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Restful WS</tspan></text>
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Activation</tspan></text>
       <path
          id="use5061-6-0-1-1-6"
          style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -798,7 +707,7 @@
            y="-272.72583"
            x="-7.1923485"
            id="tspan1500-3-9-3"
-           sodipodi:role="line">WebSocket</tspan></text>
+           sodipodi:role="line">Mail</tspan></text>
       <path
          id="use5061-6-0-7"
          style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -817,7 +726,7 @@
            y="-255.34651"
            x="-7.311367"
            id="tspan1500-31"
-           sodipodi:role="line">JSON-P</tspan></text>
+           sodipodi:role="line">Connectors</tspan></text>
       <path
          inkscape:tile-y0="-744.37067"
          inkscape:tile-x0="-59.591586"
@@ -836,7 +745,7 @@
            id="tspan1500-3-84"
            x="-7.311367"
            y="-237.85733"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">JSON-B</tspan></text>
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Restful WS</tspan></text>
       <path
          id="use5061-6-0-1-1-61"
          style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -855,7 +764,7 @@
            y="-221.54311"
            x="-7.2076073"
            id="tspan1500-3-9-9"
-           sodipodi:role="line">Concurrency</tspan></text>
+           sodipodi:role="line">WebSocket</tspan></text>
       <path
          id="use5061-6-0-6"
          style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -874,7 +783,7 @@
            y="-202.76915"
            x="-8.2635155"
            id="tspan1500-8"
-           sodipodi:role="line">Batch</tspan></text>
+           sodipodi:role="line">JSON-P</tspan></text>
       <path
          inkscape:tile-y0="-744.37067"
          inkscape:tile-x0="-59.591586"
@@ -893,7 +802,7 @@
            id="tspan1500-3-7"
            x="-7.2015038"
            y="-185.28"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Authorization</tspan></text>
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">JSON-B</tspan></text>
       <path
          id="use5061-6-0-1-1-2"
          style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -912,7 +821,7 @@
            y="-167.79083"
            x="-6.5819969"
            id="tspan1500-3-9-4"
-           sodipodi:role="line">Authentication</tspan></text>
+           sodipodi:role="line">Concurrency</tspan></text>
       <path
          id="use5061-6-0-77"
          style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -931,7 +840,7 @@
            y="-151.58647"
            x="-7.8606834"
            id="tspan1500-75"
-           sodipodi:role="line">Security</tspan></text>
+           sodipodi:role="line">Batch</tspan></text>
       <path
          inkscape:tile-y0="-744.37067"
          inkscape:tile-x0="-59.591586"
@@ -950,7 +859,7 @@
            id="tspan1500-3-2"
            x="-7.8606834"
            y="-134.00879"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Standard Tag Library</tspan></text>
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Authorization</tspan></text>
       <path
          id="use5061-6-0-1-1-1"
          style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -969,7 +878,7 @@
            y="-115.44542"
            x="-7.1923485"
            id="tspan1500-3-9-64"
-           sodipodi:role="line">Server Faces</tspan></text>
+           sodipodi:role="line">Authentication</tspan></text>
       <path
          id="use5061-6-0-5"
          style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -988,7 +897,7 @@
            y="-98.008133"
            x="-7.2015038"
            id="tspan1500-81"
-           sodipodi:role="line">Annotations</tspan></text>
+           sodipodi:role="line">Security</tspan></text>
       <path
          inkscape:tile-y0="-744.37067"
          inkscape:tile-x0="-59.591586"
@@ -1007,7 +916,7 @@
            id="tspan1500-3-1"
            x="-8.2635155"
            y="-80.50676"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Persistence</tspan></text>
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Standard Tag Library</tspan></text>
       <path
          id="use5061-6-0-1-1-57"
          style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -1026,7 +935,7 @@
            y="-62.855865"
            x="-7.1130028"
            id="tspan1500-3-9-2"
-           sodipodi:role="line">Bean Validation</tspan></text>
+           sodipodi:role="line">Faces</tspan></text>
       <path
          id="use5061-6-0-76"
          style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -1045,7 +954,7 @@
            y="-46.562992"
            x="-8.2635155"
            id="tspan1500-39"
-           sodipodi:role="line">Managed Beans</tspan></text>
+           sodipodi:role="line">Annotations</tspan></text>
       <path
          inkscape:tile-y0="-744.37067"
          inkscape:tile-x0="-59.591586"
@@ -1064,7 +973,7 @@
            id="tspan1500-3-26"
            x="-7.878994"
            y="-29.244713"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Interceptors</tspan></text>
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Persistence</tspan></text>
       <path
          id="use5061-6-0-1-1-0"
          style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -1083,29 +992,10 @@
            y="-10.498242"
            x="-6.9695702"
            id="tspan1500-3-9-21"
-           sodipodi:role="line">CDI &amp; DI</tspan></text>
-      <path
-         inkscape:tile-y0="-744.37067"
-         inkscape:tile-x0="-59.591586"
-         sodipodi:nodetypes="cccc"
-         d="m -28.680603,62.881658 h 17.48916 v -139.84893 h -17.48916 z"
-         style="color:#000000;overflow:visible;fill:#bdbfbc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="use5061-6-0-1-88" />
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583"
-         x="-8.2635155"
-         y="23.305164"
-         id="text1502-5-41"
-         transform="rotate(90)"><tspan
-           sodipodi:role="line"
-           id="tspan1500-3-79"
-           x="-8.2635155"
-           y="23.305164"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Enterprise WS</tspan></text>
+           sodipodi:role="line">Validation</tspan></text>
       <path
          id="use5061-6-0-55"
-         style="color:#000000;overflow:visible;fill:#bdbfbc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="M -11.191433,62.881658 H 6.2977272 V -76.967272 H -11.191433 Z"
          sodipodi:nodetypes="cccc"
          inkscape:tile-x0="-59.591586"
@@ -1121,10 +1011,29 @@
            y="5.9044986"
            x="-7.4578514"
            id="tspan1500-9"
-           sodipodi:role="line">XML Binding</tspan></text>
+           sodipodi:role="line">Data</tspan></text>
+      <path
+         inkscape:tile-y0="-744.37067"
+         inkscape:tile-x0="-59.591586"
+         sodipodi:nodetypes="cccc"
+         d="m -28.680603,62.881658 h 17.48916 v -139.84893 h -17.48916 z"
+         style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="use5061-6-0-1-88" />
+      <text
+         xml:space="preserve"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583"
+         x="-8.2635155"
+         y="23.305164"
+         id="text1502-5-41"
+         transform="rotate(90)"><tspan
+           sodipodi:role="line"
+           id="tspan1500-3-79"
+           x="-8.2635155"
+           y="23.305164"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Interceptors</tspan></text>
       <path
          id="use5061-6-0-1-1-4"
-         style="color:#000000;overflow:visible;fill:#bdbfbc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          d="m -46.169756,62.881658 h 17.489163 v -139.84893 h -17.489163 z"
          sodipodi:nodetypes="cccc"
          inkscape:tile-x0="-59.591586"
@@ -1140,50 +1049,7 @@
            y="42.079082"
            x="-6.9451561"
            id="tspan1500-3-9-24"
-           sodipodi:role="line">XML Web Service</tspan></text>
-      <path
-         id="use5061-6-0-53"
-         style="color:#000000;overflow:visible;fill:#bdbfbc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m -63.658916,62.881658 h 17.48916 v -139.84893 h -17.48916 z"
-         sodipodi:nodetypes="cccc"
-         inkscape:tile-x0="-59.591586"
-         inkscape:tile-y0="-744.37067" />
-      <text
-         id="text1502-44"
-         y="59.568279"
-         x="-7.6043358"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583"
-         xml:space="preserve"
-         transform="rotate(90)"><tspan
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583"
-           y="59.568279"
-           x="-7.6043358"
-           id="tspan1500-95"
-           sodipodi:role="line">WS Metadata</tspan></text>
-      <path
-         inkscape:tile-y0="-744.37067"
-         inkscape:tile-x0="-59.591586"
-         sodipodi:nodetypes="cccc"
-         d="m -99.225736,62.881658 h 35.56682 v -139.84893 h -35.56682 z"
-         style="color:#000000;overflow:visible;fill:#bdbfbc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.02359;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="use5061-6-0-1-97" />
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583"
-         x="-7.2015038"
-         y="78.28376"
-         id="text1502-5-61"
-         transform="rotate(90)"><tspan
-           sodipodi:role="line"
-           id="tspan1500-3-4"
-           x="-7.2015038"
-           y="78.28376"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">SOAP with </tspan><tspan
-           sodipodi:role="line"
-           x="-7.2015038"
-           y="93.90876"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583"
-           id="tspan1837">Attachments</tspan></text>
+           sodipodi:role="line">CDI &amp; DI</tspan></text>
     </g>
     <g
        id="g2128"
@@ -1282,82 +1148,6 @@
         <g
            id="g1345">
           <path
-             id="use5061-6-0-1-1-25"
-             style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-             d="m -50.126145,435.86553 h 17.48916 V 296.0166 h -17.48916 z"
-             sodipodi:nodetypes="cccc"
-             inkscape:tile-x0="-59.591586"
-             inkscape:tile-y0="-744.37067" />
-          <text
-             transform="rotate(90)"
-             id="text1502-5-1-96"
-             y="44.665257"
-             x="365.89529"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583"
-             xml:space="preserve"><tspan
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583"
-               y="44.665257"
-               x="365.89529"
-               id="tspan1500-3-9-37"
-               sodipodi:role="line">Messaging</tspan></text>
-          <path
-             id="use5061-6-0-1-8-3"
-             style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-             d="m -67.615305,435.86553 h 17.48916 V 296.0166 h -17.48916 z"
-             sodipodi:nodetypes="cccc"
-             inkscape:tile-x0="-59.591586"
-             inkscape:tile-y0="-744.37067" />
-          <text
-             transform="rotate(90)"
-             id="text1502-5-5-8"
-             y="63.350708"
-             x="365.78238"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583"
-             xml:space="preserve"><tspan
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583"
-               y="63.350708"
-               x="365.78238"
-               id="tspan1500-3-8-0"
-               sodipodi:role="line">Activation</tspan></text>
-          <path
-             inkscape:tile-y0="-744.37067"
-             inkscape:tile-x0="-59.591586"
-             sodipodi:nodetypes="cccc"
-             d="m -85.104465,435.86553 h 17.48916 V 296.0166 h -17.48916 z"
-             style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-             id="use5061-6-0-1-1-5-8" />
-          <text
-             transform="rotate(90)"
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583"
-             x="365.9075"
-             y="81.013794"
-             id="text1502-5-1-1-3"><tspan
-               sodipodi:role="line"
-               id="tspan1500-3-9-6-1"
-               x="365.9075"
-               y="81.013794"
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Mail</tspan></text>
-          <path
-             inkscape:tile-y0="-744.37067"
-             inkscape:tile-x0="-59.591586"
-             sodipodi:nodetypes="cccc"
-             d="m -102.59363,435.86553 h 17.489165 V 296.0166 h -17.489165 z"
-             style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-             id="use5061-6-0-7-9" />
-          <text
-             transform="rotate(90)"
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583"
-             x="365.67252"
-             y="98.393112"
-             id="text1502-8-8"><tspan
-               sodipodi:role="line"
-               id="tspan1500-31-7"
-               x="365.67252"
-               y="98.393112"
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">JSON-P</tspan></text>
-          <path
              id="use5061-6-0-1-6-2"
              style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              d="m -120.08281,435.86553 h 17.48916 V 296.0166 h -17.48916 z"
@@ -1375,7 +1165,7 @@
                y="115.88229"
                x="365.67252"
                id="tspan1500-3-84-2"
-               sodipodi:role="line">JSON-B</tspan></text>
+               sodipodi:role="line">Messaging</tspan></text>
           <path
              inkscape:tile-y0="-744.37067"
              inkscape:tile-x0="-59.591586"
@@ -1394,7 +1184,7 @@
                id="tspan1500-81-9"
                x="365.78238"
                y="133.30737"
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Annotations</tspan></text>
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Activation</tspan></text>
           <path
              id="use5061-6-0-1-98-3"
              style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -1413,7 +1203,7 @@
                y="150.80875"
                x="364.72037"
                id="tspan1500-3-1-1"
-               sodipodi:role="line">Persistence</tspan></text>
+               sodipodi:role="line">Mail</tspan></text>
           <path
              inkscape:tile-y0="-744.37067"
              inkscape:tile-x0="-59.591586"
@@ -1432,7 +1222,7 @@
                id="tspan1500-3-9-2-9"
                x="365.87088"
                y="168.45964"
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Bean Validation</tspan></text>
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">JSON-P</tspan></text>
           <path
              inkscape:tile-y0="-744.37067"
              inkscape:tile-x0="-59.591586"
@@ -1451,7 +1241,7 @@
                id="tspan1500-39-1"
                x="364.72037"
                y="184.7525"
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Managed Beans</tspan></text>
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">JSON-B</tspan></text>
           <path
              id="use5061-6-0-1-96-7"
              style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -1470,7 +1260,7 @@
                y="202.07079"
                x="365.10489"
                id="tspan1500-3-26-0"
-               sodipodi:role="line">Interceptors</tspan></text>
+               sodipodi:role="line">Annotations</tspan></text>
           <path
              inkscape:tile-y0="-744.37067"
              inkscape:tile-x0="-59.591586"
@@ -1489,10 +1279,29 @@
                id="tspan1500-3-9-21-9"
                x="366.01431"
                y="220.81726"
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">CDI &amp; DI</tspan></text>
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Persistence</tspan></text>
+          <path
+             inkscape:tile-y0="-744.37067"
+             inkscape:tile-x0="-59.591586"
+             sodipodi:nodetypes="cccc"
+             d="m -242.50693,435.86553 h 17.48916 V 296.0166 h -17.48916 z"
+             style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             id="use5061-6-0-55-3" />
+          <text
+             transform="rotate(90)"
+             xml:space="preserve"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583"
+             x="365.52603"
+             y="237.22"
+             id="text1502-36-2"><tspan
+               sodipodi:role="line"
+               id="tspan1500-9-2"
+               x="365.52603"
+               y="237.22"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Validation</tspan></text>
           <path
              id="use5061-6-0-1-88-2"
-             style="color:#000000;overflow:visible;fill:#bdbfbc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              d="m -259.9961,435.86553 h 17.48916 V 296.0166 h -17.48916 z"
              sodipodi:nodetypes="cccc"
              inkscape:tile-x0="-59.591586"
@@ -1508,32 +1317,13 @@
                y="254.6207"
                x="364.72037"
                id="tspan1500-3-79-9"
-               sodipodi:role="line">Enterprise WS</tspan></text>
-          <path
-             inkscape:tile-y0="-744.37067"
-             inkscape:tile-x0="-59.591586"
-             sodipodi:nodetypes="cccc"
-             d="m -242.50693,435.86553 h 17.48916 V 296.0166 h -17.48916 z"
-             style="color:#000000;overflow:visible;fill:#bdbfbc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-             id="use5061-6-0-55-3" />
-          <text
-             transform="rotate(90)"
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583"
-             x="365.52603"
-             y="237.22"
-             id="text1502-36-2"><tspan
-               sodipodi:role="line"
-               id="tspan1500-9-2"
-               x="365.52603"
-               y="237.22"
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">XML Binding</tspan></text>
+               sodipodi:role="line">Interceptors</tspan></text>
           <path
              inkscape:tile-y0="-744.37067"
              inkscape:tile-x0="-59.591586"
              sodipodi:nodetypes="cccc"
              d="m -277.48526,435.86553 h 17.48917 V 296.0166 h -17.48917 z"
-             style="color:#000000;overflow:visible;fill:#bdbfbc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
              id="use5061-6-0-1-1-4-2" />
           <text
              transform="rotate(90)"
@@ -1546,50 +1336,7 @@
                id="tspan1500-3-9-24-5"
                x="366.03873"
                y="273.39456"
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">XML Web Service</tspan></text>
-          <path
-             inkscape:tile-y0="-744.37067"
-             inkscape:tile-x0="-59.591586"
-             sodipodi:nodetypes="cccc"
-             d="m -294.97442,435.86553 h 17.48916 V 296.0166 h -17.48916 z"
-             style="color:#000000;overflow:visible;fill:#bdbfbc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-             id="use5061-6-0-53-3" />
-          <text
-             transform="rotate(90)"
-             xml:space="preserve"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583"
-             x="365.37955"
-             y="290.88376"
-             id="text1502-44-4"><tspan
-               sodipodi:role="line"
-               id="tspan1500-95-5"
-               x="365.37955"
-               y="290.88376"
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">WS Metadata</tspan></text>
-          <path
-             id="use5061-6-0-1-97-6"
-             style="color:#000000;overflow:visible;fill:#bdbfbc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.02359;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-             d="m -330.54124,435.86553 h 35.56682 V 296.0166 h -35.56682 z"
-             sodipodi:nodetypes="cccc"
-             inkscape:tile-x0="-59.591586"
-             inkscape:tile-y0="-744.37067" />
-          <text
-             transform="rotate(90)"
-             id="text1502-5-61-8"
-             y="309.59924"
-             x="365.78238"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583"
-             xml:space="preserve"><tspan
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583"
-               y="309.59924"
-               x="365.78238"
-               id="tspan1500-3-4-3"
-               sodipodi:role="line">SOAP with </tspan><tspan
-               id="tspan1837-7"
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583"
-               y="325.22424"
-               x="365.78238"
-               sodipodi:role="line">Attachments</tspan></text>
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">CDI &amp; DI</tspan></text>
         </g>
       </g>
     </g>
@@ -1686,63 +1433,6 @@
          id="g3830"
          transform="matrix(5.0092536,0,0,4.9998642,-325.75061,-1037.0734)">
         <path
-           inkscape:tile-y0="-744.37067"
-           inkscape:tile-x0="-59.591586"
-           sodipodi:nodetypes="cccc"
-           d="m 510.56806,412.78773 h 17.48916 V 272.9388 h -17.48916 z"
-           style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="use5061-6-0-1-1-7" />
-        <text
-           xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583"
-           x="342.81769"
-           y="-516.02893"
-           id="text1502-5-1-0"
-           transform="rotate(90)"><tspan
-             sodipodi:role="line"
-             id="tspan1500-3-9-5"
-             x="342.81769"
-             y="-516.02893"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Messaging</tspan></text>
-        <path
-           id="use5061-6-0-9-8"
-           style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 493.0789,412.78773 h 17.48916 V 272.9388 H 493.0789 Z"
-           sodipodi:nodetypes="cccc"
-           inkscape:tile-x0="-59.591586"
-           inkscape:tile-y0="-744.37067" />
-        <text
-           id="text1502-4-7"
-           y="-497.34351"
-           x="342.86346"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583"
-           xml:space="preserve"
-           transform="rotate(90)"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583"
-             y="-497.34351"
-             x="342.86346"
-             id="tspan1500-7-3"
-             sodipodi:role="line">Transactions</tspan></text>
-        <path
-           inkscape:tile-y0="-744.37067"
-           inkscape:tile-x0="-59.591586"
-           sodipodi:nodetypes="cccc"
-           d="m 475.58973,412.78773 h 17.48916 V 272.9388 h -17.48916 z"
-           style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="use5061-6-0-1-8-38" />
-        <text
-           xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583"
-           x="342.70477"
-           y="-479.85431"
-           id="text1502-5-5-6"
-           transform="rotate(90)"><tspan
-             sodipodi:role="line"
-             id="tspan1500-3-8-7"
-             x="342.70477"
-             y="-479.85431"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Activation</tspan></text>
-        <path
            id="use5061-6-0-1-1-5-2"
            style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            d="m 458.10057,412.78773 h 17.48916 V 272.9388 h -17.48916 z"
@@ -1760,7 +1450,7 @@
              y="-462.19122"
              x="342.8299"
              id="tspan1500-3-9-6-7"
-             sodipodi:role="line">Mail</tspan></text>
+             sodipodi:role="line">Messaging</tspan></text>
         <path
            id="use5061-6-0-3-8"
            style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -1779,7 +1469,7 @@
              y="-444.82416"
              x="342.16156"
              id="tspan1500-4-8"
-             sodipodi:role="line">Connectors</tspan></text>
+             sodipodi:role="line">Transactions</tspan></text>
         <path
            id="use5061-6-0-7-90"
            style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -1798,7 +1488,7 @@
              y="-427.32275"
              x="342.59491"
              id="tspan1500-31-3"
-             sodipodi:role="line">JSON-P</tspan></text>
+             sodipodi:role="line">Activation</tspan></text>
         <path
            inkscape:tile-y0="-744.37067"
            inkscape:tile-x0="-59.591586"
@@ -1817,7 +1507,7 @@
              id="tspan1500-3-84-1"
              x="342.59491"
              y="-409.83362"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">JSON-B</tspan></text>
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Mail</tspan></text>
         <path
            id="use5061-6-0-1-1-61-5"
            style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -1836,7 +1526,7 @@
              y="-393.51935"
              x="342.69867"
              id="tspan1500-3-9-9-0"
-             sodipodi:role="line">Concurrency</tspan></text>
+             sodipodi:role="line">Connectors</tspan></text>
         <path
            id="use5061-6-0-6-3"
            style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -1855,7 +1545,7 @@
              y="-374.74542"
              x="341.64276"
              id="tspan1500-8-7"
-             sodipodi:role="line">Batch</tspan></text>
+             sodipodi:role="line">JSON-P</tspan></text>
         <path
            inkscape:tile-y0="-744.37067"
            inkscape:tile-x0="-59.591586"
@@ -1874,7 +1564,7 @@
              id="tspan1500-3-7-3"
              x="342.70477"
              y="-357.25626"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Authorization</tspan></text>
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">JSON-B</tspan></text>
         <path
            id="use5061-6-0-1-1-2-8"
            style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -1893,7 +1583,7 @@
              y="-339.76709"
              x="343.32428"
              id="tspan1500-3-9-4-6"
-             sodipodi:role="line">Authentication</tspan></text>
+             sodipodi:role="line">Concurrency</tspan></text>
         <path
            id="use5061-6-0-77-9"
            style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -1912,7 +1602,7 @@
              y="-323.56274"
              x="342.04559"
              id="tspan1500-75-4"
-             sodipodi:role="line">Security</tspan></text>
+             sodipodi:role="line">Batch</tspan></text>
         <path
            id="use5061-6-0-5-4"
            style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -1931,7 +1621,7 @@
              y="-304.96274"
              x="342.70477"
              id="tspan1500-81-97"
-             sodipodi:role="line">Annotations</tspan></text>
+             sodipodi:role="line">Authorization</tspan></text>
         <path
            inkscape:tile-y0="-744.37067"
            inkscape:tile-x0="-59.591586"
@@ -1950,7 +1640,7 @@
              id="tspan1500-3-1-5"
              x="341.64276"
              y="-287.46136"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Persistence</tspan></text>
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Authentication</tspan></text>
         <path
            id="use5061-6-0-1-1-57-67"
            style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -1969,7 +1659,7 @@
              y="-269.81046"
              x="342.79327"
              id="tspan1500-3-9-2-0"
-             sodipodi:role="line">Bean Validation</tspan></text>
+             sodipodi:role="line">Security</tspan></text>
         <path
            id="use5061-6-0-76-8"
            style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -1988,7 +1678,7 @@
              y="-253.51758"
              x="341.64276"
              id="tspan1500-39-5"
-             sodipodi:role="line">Managed Beans</tspan></text>
+             sodipodi:role="line">Annotations</tspan></text>
         <path
            inkscape:tile-y0="-744.37067"
            inkscape:tile-x0="-59.591586"
@@ -2007,7 +1697,7 @@
              id="tspan1500-3-26-08"
              x="342.02728"
              y="-236.19931"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Interceptors</tspan></text>
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Persistence</tspan></text>
         <path
            id="use5061-6-0-1-1-0-8"
            style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -2026,29 +1716,10 @@
              y="-217.45282"
              x="342.93671"
              id="tspan1500-3-9-21-93"
-             sodipodi:role="line">CDI &amp; DI</tspan></text>
-        <path
-           inkscape:tile-y0="-744.37067"
-           inkscape:tile-x0="-59.591586"
-           sodipodi:nodetypes="cccc"
-           d="m 178.27399,412.78773 h 17.48916 V 272.9388 h -17.48916 z"
-           style="color:#000000;overflow:visible;fill:#bdbfbc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="use5061-6-0-1-88-4" />
-        <text
-           xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583"
-           x="341.64276"
-           y="-183.64941"
-           id="text1502-5-41-3"
-           transform="rotate(90)"><tspan
-             sodipodi:role="line"
-             id="tspan1500-3-79-6"
-             x="341.64276"
-             y="-183.64941"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Enterprise WS</tspan></text>
+             sodipodi:role="line">Validation</tspan></text>
         <path
            id="use5061-6-0-55-4"
-           style="color:#000000;overflow:visible;fill:#bdbfbc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            d="m 195.76316,412.78773 h 17.48916 V 272.9388 h -17.48916 z"
            sodipodi:nodetypes="cccc"
            inkscape:tile-x0="-59.591586"
@@ -2064,10 +1735,29 @@
              y="-201.05008"
              x="342.44843"
              id="tspan1500-9-5"
-             sodipodi:role="line">XML Binding</tspan></text>
+             sodipodi:role="line">Data</tspan></text>
+        <path
+           inkscape:tile-y0="-744.37067"
+           inkscape:tile-x0="-59.591586"
+           sodipodi:nodetypes="cccc"
+           d="m 178.27399,412.78773 h 17.48916 V 272.9388 h -17.48916 z"
+           style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="use5061-6-0-1-88-4" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583"
+           x="341.64276"
+           y="-183.64941"
+           id="text1502-5-41-3"
+           transform="rotate(90)"><tspan
+             sodipodi:role="line"
+             id="tspan1500-3-79-6"
+             x="341.64276"
+             y="-183.64941"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">Interceptors</tspan></text>
         <path
            id="use5061-6-0-1-1-4-6"
-           style="color:#000000;overflow:visible;fill:#bdbfbc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="color:#000000;overflow:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            d="M 160.78483,412.78773 H 178.274 V 272.9388 h -17.48917 z"
            sodipodi:nodetypes="cccc"
            inkscape:tile-x0="-59.591586"
@@ -2083,50 +1773,7 @@
              y="-164.87552"
              x="342.96112"
              id="tspan1500-3-9-24-2"
-             sodipodi:role="line">XML Web Service</tspan></text>
-        <path
-           id="use5061-6-0-53-8"
-           style="color:#000000;overflow:visible;fill:#bdbfbc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.022;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 143.29567,412.78773 h 17.48916 V 272.9388 h -17.48916 z"
-           sodipodi:nodetypes="cccc"
-           inkscape:tile-x0="-59.591586"
-           inkscape:tile-y0="-744.37067" />
-        <text
-           id="text1502-44-8"
-           y="-147.38632"
-           x="342.30194"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583"
-           xml:space="preserve"
-           transform="rotate(90)"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583"
-             y="-147.38632"
-             x="342.30194"
-             id="tspan1500-95-2"
-             sodipodi:role="line">WS Metadata</tspan></text>
-        <path
-           inkscape:tile-y0="-744.37067"
-           inkscape:tile-x0="-59.591586"
-           sodipodi:nodetypes="cccc"
-           d="m 107.72885,412.78773 h 35.56682 V 272.9388 h -35.56682 z"
-           style="color:#000000;overflow:visible;fill:#bdbfbc;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1.02359;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="use5061-6-0-1-97-64" />
-        <text
-           xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;line-height:1.25;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583"
-           x="342.70477"
-           y="-128.67084"
-           id="text1502-5-61-3"
-           transform="rotate(90)"><tspan
-             sodipodi:role="line"
-             id="tspan1500-3-4-9"
-             x="342.70477"
-             y="-128.67084"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583">SOAP with </tspan><tspan
-             sodipodi:role="line"
-             x="342.70477"
-             y="-113.04584"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.5px;font-family:sans-serif;-inkscape-font-specification:sans-serif;text-align:center;text-anchor:middle;stroke-width:0.264583"
-             id="tspan1837-4">Attachments</tspan></text>
+             sodipodi:role="line">CDI &amp; DI</tspan></text>
       </g>
     </g>
     <text

--- a/specification/src/main/asciidoc/platform/ApplicationAssemblyDeployment.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationAssemblyDeployment.adoc
@@ -214,7 +214,7 @@ resource of the required type.
 
 Some resources have default mapping rules
 specified; see sections <<a2009, Default Data Source>>, <<a2025, Default Jakarta Messaging Connection Factory>>, and
-<<a2042, Default Concurrency Utilities Objects>>. By default, a product must map otherwise unmapped
+<<a2042, Default Jakarta Concurrency Objects>>. By default, a product must map otherwise unmapped
 resources using these default rules. A product may include an option to
 disable or override these default mapping rules.
 

--- a/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
+++ b/specification/src/main/asciidoc/platform/ApplicationProgrammingInterface.adoc
@@ -16,7 +16,7 @@ runtime environments provided by the containers that are a part of the
 Jakarta EE platform. The Jakarta EE platform supports three types of
 containers corresponding to Jakarta EE application component types:
 application client containers; web containers for
-servlets, server pages, server faces applications,
+Servlets, Pages, Faces, and
 RESTful web services applications;
 and enterprise bean containers. A Jakarta EE profile may support only a subset
 of these component types, as defined by the individual Jakarta EE profile
@@ -173,6 +173,11 @@ technology will no longer be maintained for future versions of the Platform.
 |Y
 |N
 
+|Faces
+|N
+|Y
+|N
+
 |Interceptors
 |Y
 |Y
@@ -217,11 +222,6 @@ technology will no longer be maintained for future versions of the Platform.
 |N
 |Y
 |Y
-
-|Server Faces
-|N
-|Y
-|N
 
 |Servlet
 |N
@@ -528,7 +528,7 @@ EE platform.
 
 A Jakarta EE product that supports the following
 types of objects must be able to make them available in the
-application’s JNDI namespace: _EJBHome_ objects, _EJBLocalHome_ objects,
+application’s JNDI namespace:
 Enterprise Beans business interface objects, Jakarta Transactions _UserTransaction_ objects, JDBC API
 _DataSource_ objects, Jakarta Messaging _ConnectionFactory_ and _Destination_ objects,
 Jakarta Mail _Session_ objects, _URL_ objects, resource manager
@@ -691,9 +691,7 @@ _putValue_ methods:
 
 *  _java.io.Serializable_
 *  _jakarta.ejb.EJBObject_
-*  _jakarta.ejb.EJBHome_
 *  _jakarta.ejb.EJBLocalObject_
-*  _jakarta.ejb.EJBLocalHome_
 *  _jakarta.transaction.UserTransaction_
 * a _javax.naming.Context_ object for the
 _java:comp/env_ context
@@ -1109,13 +1107,13 @@ found at _https://jakarta.ee/specifications/security/_ .
 
 === Debugging Support for Other Languages 2.0 Requirements
 
-Server pages are usually translated into Java
+Jakarta Pages are usually translated into Java
 language pages and then compiled to create class files. The Jakarta Debugging Support for Other Languages
 specification describes information that can
 be included in a class file to relate class file data to data in the
 original source file. All Jakarta EE products are required to be able to
 include such information in class files that are generated from
-server pages.
+Jakarta Pages.
 
 The Jakarta Debugging Support for Other Languages
 specification can be found at _https://jakarta.ee/specifications/debugging/_ .
@@ -1123,24 +1121,24 @@ specification can be found at _https://jakarta.ee/specifications/debugging/_ .
 === Standard Tag Library 3.0 Requirements
 
 The Jakarta Standard Tag Library specification defines a standard tag library that
-makes it easier to develop server pages. A Jakarta EE product must support
-Jakarta Standard Tag Library specification for use by all server pages.
+makes it easier to develop Jakarta Pages. A Jakarta EE product must support
+Jakarta Standard Tag Library specification for use by all Jakarta Pages.
 
 The Jakarta Standard Tag Library
 specification can be found at _https://jakarta.ee/specifications/tags/_ .
 
-=== Server Faces 4.1 Requirements
+=== Faces 4.1 Requirements
 
-Jakarta Server Faces technology simplifies
+Jakarta Faces technology simplifies
 building user interfaces for Jakarta applications. Developers of
 various skill levels can quickly build web applications by: assembling
 reusable UI components in a page; connecting these components to an
 application data source; and wiring client-generated events to
 server-side event handlers. In a Jakarta EE product, all Jakarta EE web
-containers are required to support applications that use the Jakarta Server
+containers are required to support applications that use the Jakarta
 Faces technology.
 
-The Jakarta Server Faces specification can be
+The Jakarta Faces specification can be
 found at _https://jakarta.ee/specifications/faces/_ .
 
 === Annotations 3.0 Requirements
@@ -1272,7 +1270,7 @@ source is annotations, with the ability to override and extend the
 metadata through the use of XML validation descriptors.
 
 The Jakarta EE platform requires that web
-containers make an instance of _ValidatorFactory_ available to Jakarta Server Faces
+containers make an instance of _ValidatorFactory_ available to Jakarta Faces
 implementations by storing it in a servlet context attribute named
 _jakarta.faces.validator.beanValidator.ValidatorFactory._
 

--- a/specification/src/main/asciidoc/platform/Interoperability.adoc
+++ b/specification/src/main/asciidoc/platform/Interoperability.adoc
@@ -146,7 +146,7 @@ generation, transformation, and querying of JSON text. The Jakarta JSON Binding 
 provides support for mapping between JSON text and Java objects.
 * HTML 4.01—This version represents the minimum web
 browser standard document format. While all Jakarta EE APIs with the
-exception of Jakarta Server Faces are agnostic to the version of the browser document
+exception of Jakarta Faces are agnostic to the version of the browser document
 format, Jakarta EE web clients must be able to display HTML 4.01 documents.
 * Image file formats—The Jakarta EE platform must
 support GIF, JPEG, and PNG images. Support for these formats is provided

--- a/specification/src/main/asciidoc/platform/PlatformOverview.adoc
+++ b/specification/src/main/asciidoc/platform/PlatformOverview.adoc
@@ -27,8 +27,8 @@ The arrows represent required access to other
 parts of the Jakarta EE platform. The Application Client Container provides
 Application Clients with direct access to the Jakarta EE required Database
 through the Java API for connectivity with database systems, the JDBC™
-API. Similar access to databases is provided to server pages, server faces
-applications, and servlets by the Web Container, and to enterprise beans
+API. Similar access to databases is provided to Pages, Faces, and 
+Servlets by the Web Container, and to enterprise beans
 by the Enterprise Beans Container.
 
 As indicated, the APIs of the Java™
@@ -125,15 +125,15 @@ language programs that are typically GUI programs that execute on a
 desktop computer. Application clients offer a user experience similar to
 that of native applications and have access to all of the facilities of
 the Jakarta EE middle tier.
-* Servlets, Server Pages, Server Faces applications,
+* Servlets, Pages, Faces applications,
 Filters, and Web Event Listeners typically execute in a web container
-and may respond to HTTP requests from web clients. Servlets, server pages,
-server faces applications, and filters may be used to generate HTML pages that
+and may respond to HTTP requests from web clients. Servlets, Pages,
+Faces applications, and Filters may be used to generate HTML pages that
 are an application’s user interface. They may also be used to generate
 XML or other format data that is consumed by other application
 components. A special kind of servlet may provide support for web services
 using the SOAP/HTTP protocol. Servlets, pages created with the
-Jakarta Pages technology or Jakarta Server Faces technology, web
+Jakarta Pages technology or Jakarta Faces technology, web
 filters, and web event listeners are referred to collectively in this
 specification as “web components.” Web applications are composed of web
 components and other data such as HTML pages. Web components execute in
@@ -248,7 +248,7 @@ these standard services are actually provided by Java SE.
 
 The HTTP client-side API is defined by the _java.net_ package. The
 HTTP server-side API is defined and used by the Jakarta RESTful Web Services,
-Jakarta Servlet, Jakarta Pages, and Jakarta Server Faces
+Jakarta Servlet, Jakarta Pages, and Jakarta Faces
 interfaces and by Jakarta XML Web Services support that is no longer a required part of
 the Jakarta EE platform.
 
@@ -326,12 +326,12 @@ parts: an application-level interface used by the application components
 to send mail, and a service provider interface used at the Jakarta EE SPI
 level.
 
-==== Jakarta Activation Framework (JAF)
+==== Jakarta Activation
 
-The JAF API provides a framework for handling
+The Jakarta Activation API provides a framework for handling
 data in different MIME types, originating in different formats and
-locations. The Jakarta Mail API makes use of the JAF API. As of Jakarta EE 9, 
-the Jakarta Activation Framework is now part of the Jakarta EE Platform.
+locations. The Jakarta Mail API makes use of the Jakarta Activation API. As of Jakarta EE 9, 
+Jakarta Activation is now part of the Jakarta EE Platform.
 
 ==== XML Processing
 
@@ -667,7 +667,7 @@ may customize the business logic of the application’s components at
 deployment time. For example, using tools provided with a Jakarta EE
 product, the Deployer may provide simple application code that wraps an
 enterprise bean’s business methods, or customizes the appearance of a
-server pages or server faces page.
+Pages or Faces page.
 
 The Deployer’s output is web applications,
 enterprise beans, and application clients that have been
@@ -761,8 +761,8 @@ details on the network protocol support required for interoperability.
 
 The Jakarta EE Product Provider is required to
 publish the installed application components on the industry-standard
-protocols. This specification defines the mapping of servlets and server
-pages to the HTTP and HTTPS protocols, and the mapping of Jakarta Enterprise Beans components
+protocols. This specification defines the mapping of Servlets and
+Pages to the HTTP and HTTPS protocols, and the mapping of Jakarta Enterprise Beans components
 to IIOP and SOAP protocols.  Jakarta SOAP with Attachments is no longer required by Jakarta EE 11.
 See <<a2333, Removed Jakarta Technologies>>.
 
@@ -1013,14 +1013,14 @@ No API updates are expected in Jakarta EE 9.1.
 Only the Platform and Web Profile Specifications along with the TCKs and Compatible Implementations should be affected by Jakarta EE 9.1.
 
 === Changes in Jakarta EE 10
-The goal of the Jakarta EE 10 release is to deliver a set of specifications that and adding the support for the Java SE 11 and newer runtimes. The TCKs require support for both Java SE 11 and Java SE 17.
+The Jakarta EE 10 release removes support for Java SE 8. It includes support for Java SE 11 and newer runtimes. The TCKs require support for both Java SE 11 and Java SE 17.
 
 Jakarta EE 10 is the first release in the Jakarta EE series to include major and minor component specification updates not limited to the javax to jakarta package namespace change.
 
 Jakarta EE 10 also introduced a new Core Profile to support smaller runtime footprints as often used with microservices.
 
 === Changes in Jakarta EE 11
-The goal of the Jakarta EE 11 release is to deliver a set of specifications that and adding the support for the Java SE 17 and newer runtimes. The TCKs require support for both Java SE 17 and Java SE 21.
+The Jakarta EE 11 release removes support for Java SE 11. It includes support for Java SE 17 and newer runtimes. The TCKs require support for both Java SE 17 and Java SE 21.
 
 Jakarta EE 11 removes the following technologies from the platform.
 

--- a/specification/src/main/asciidoc/platform/Profiles.adoc
+++ b/specification/src/main/asciidoc/platform/Profiles.adoc
@@ -194,6 +194,7 @@ The following technologies are required:
 * Jakarta Dependency Injection 2.0
 * Jakarta Enterprise Beans 4.0 (except for Jakarta Enterprise Beans entity beans and associated Jakarta Enterprise Beans QL, and embedded container, which have been made removed)
 * Jakarta Expression Language 6.0*
+* Jakarta Faces 4.1*
 * Jakarta Interceptors 2.2*
 * Jakarta JSON Processing 2.1
 * Jakarta JSON Binding 3.0
@@ -204,7 +205,6 @@ The following technologies are required:
 * Jakarta RESTful Web Services 4.0*
 * Jakarta Security 4.0*
 * Jakarta Servlet 6.1*
-* Jakarta Server Faces 4.1*
 * Jakarta Standard Tag Library 3.0
 * Jakarta Transactions 2.0
 * Jakarta Validation 3.1*

--- a/specification/src/main/asciidoc/platform/RelatedDocuments.adoc
+++ b/specification/src/main/asciidoc/platform/RelatedDocuments.adoc
@@ -16,7 +16,7 @@ _Java™ Platform, Standard Edition, v17 API Specification_. Available at: _http
 
 _Jakarta™ Enterprise Beans Specification, Version 4.0_. Available at: _https://jakarta.ee/specifications/enterprise-beans/4.0/_
 
-_Jakarta™ Server Pages Specification, Version 4.0_. Available at: _https://jakarta.ee/specifications/pages/4.0/_
+_Jakarta™ Pages Specification, Version 4.0_. Available at: _https://jakarta.ee/specifications/pages/4.0/_
 
 _Jakarta™ Expression Language Specification, Version 6.0_. Available at: _https://jakarta.ee/specifications/expression-language/6.0/_
 
@@ -54,7 +54,7 @@ _Jakarta™ Debugging Support for Other Languages Specification, Version 2.0_. A
 
 _Jakarta™ Standard Tag Library Specification, Version 3.0_. Available at: _https://jakarta.ee/specifications/tags/3.0/_
 
-_Jakarta™ Server Faces Specification, Version 4.1_. Available at: _https://jakarta.ee/specifications/faces/4.1/_
+_Jakarta™ Faces Specification, Version 4.1_. Available at: _https://jakarta.ee/specifications/faces/4.1/_
 
 _Jakarta™ Persistence Specification, Version 3.2_. Available at: _https://jakarta.ee/specifications/persistence/3.2/_
 

--- a/specification/src/main/asciidoc/platform/ResourcesNamingInjection.adoc
+++ b/specification/src/main/asciidoc/platform/ResourcesNamingInjection.adoc
@@ -476,8 +476,8 @@ Standard
 
 Standard
 
-|Jakarta Server Faces
-|managed classes footnote:[See the Jakarta™ Server Faces
+|Jakarta Faces
+|managed classes footnote:[See the Jakarta™ Faces
 specification section Jakarta Faces Managed Classes and Jakarta EE Annotations” for
 a list of these managed classes.]
 |Standard
@@ -1246,7 +1246,7 @@ public void changePhoneNumber(...) {
   // Obtain the default initial JNDI context.
   Context initCtx = new InitialContext();
 
-  // Look up the home interface of the EmployeeRecord
+  // Look up the interface of the EmployeeRecord
   // enterprise bean in the environment.
   EmployeeRecord result = (EmployeeRecord) initCtx.lookup("java:comp/env/ejb/EmplRecord");
  ...

--- a/specification/src/main/asciidoc/platform/Security.adoc
+++ b/specification/src/main/asciidoc/platform/Security.adoc
@@ -127,15 +127,15 @@ returns the result of the original URL request, as shown in
 .Fulfilling the Original Request
 image::Step4.svg[]
 
-In our example, the response URL of a server page
+In our example, the response URL of a Pages page
 is returned, enabling the user to post form data that needs to be
 handled by the business logic component of the application.
 
 Invoking Enterprise Bean Business Methods::
 
-The server page performs the remote method call to
+The Pages page performs the remote method call to
 the enterprise bean, using the user’s credential to establish a secure
-association between the server page and the enterprise bean (as shown in
+association between the Pages page and the enterprise bean (as shown in
 <<a269, Invoking an Enterprise Bean Business Method>> ). 
 The association is implemented as two related
 security contexts, one in the web server and one in the Jakarta Enterprise Beans container.
@@ -157,11 +157,11 @@ authorized” outcome when the container is able to map the caller’s
 credential to a role. A “not authorized” outcome is reached if the
 container is unable to map the caller to any of the permitted roles. A
 “not authorized” result causes an exception to be thrown by the
-container, and propagated back to the calling server page.
+container, and propagated back to the calling Pages page.
 
 If the user is authorized, the container
 dispatches control to the enterprise bean method. The result of the
-bean’s execution of the call is returned to the server page, and ultimately to
+bean’s execution of the call is returned to the Pages page, and ultimately to
 the user by the web server and the web client.
 
 === Security Architecture
@@ -530,7 +530,7 @@ feature of the Jakarta EE platform.
 The look and feel of a login screen cannot be
 varied using the web browser’s built-in authentication mechanisms. This
 specification introduces the ability to package standard HTML or
-servlet, server pages, or server faces based forms for logging in, allowing customization of
+Servlet, Pages, or Faces based forms for logging in, allowing customization of
 the user interface. The form based authentication mechanism introduced
 by this specification is described in the Servlet specification.
 
@@ -877,10 +877,10 @@ single application within a single Jakarta EE product, the principal name
 returned by the _EJBContext_ method _getCallerPrincipal_ or the
 _SecurityContext_ method _getCallerPrincipal_ must be the same as that
 returned by the first enterprise bean in the call chain. If the first
-enterprise bean in the call chain is called by a servlet or server page,
+enterprise bean in the call chain is called by a servlet or Pages page,
 the principal name must be the same as that returned by the
 _HttpServletRequest_ method _getUserPrincipal_ or the _SecurityContext_
-method _getCallerPrincipal_ in the calling servlet or server page.
+method _getCallerPrincipal_ in the calling servlet or Pages page.
 (However, if the _HttpServletRequest_ or _SecurityContext_ method
 _getCallerPrincipal_ returns _null_ , the principal used in calls to
 enterprise beans is not specified by this specification, although it

--- a/specification/src/main/asciidoc/platform/TransactionManagement.adoc
+++ b/specification/src/main/asciidoc/platform/TransactionManagement.adoc
@@ -28,13 +28,13 @@ for the Jakarta Connectors specification, each component may also acquire one or
 connections to access one or more transactional resource managers.
 
 For example, in
-<<a475, Servlets/Server Pages Accessing Enterprise Beans>> , the call
-tree starts from a servlet or server page accessing multiple enterprise beans,
+<<a475, Servlets/Pages Accessing Enterprise Beans>> , the call
+tree starts from a servlet or Pages page accessing multiple enterprise beans,
 which in turn may access other enterprise beans. The components access resource
 managers via connections.
 
 [[a475]]
-.Servlets/Server Pages Accessing Enterprise Beans
+.Servlets/Pages Accessing Enterprise Beans
 image::accessing-EJBs.svg[]
 
 The Application Component Provider specifies, using a combination of
@@ -42,7 +42,7 @@ programmatic and declarative transaction demarcation APIs, how the platform
 must manage transactions on behalf of the application.
 
 For example, the application may require that all the components in
-<<a475, Servlets/Server Pages Accessing Enterprise Beans>> access
+<<a475, Servlets/Pages Accessing Enterprise Beans>> access
 resources as part of a single transaction. The Platform Provider must provide
 the transaction capabilities to support such a scenario.
 
@@ -134,11 +134,11 @@ The Product Provider is not required to support transaction context propagation
 via an HTTP request across web components. The HTTP protocol does not support
 such transaction context propagation. When a web component associated with a
 transaction makes an HTTP request to another web component, the transaction
-context is not propagated to the target servlet or server page.
+context is not propagated to the target servlet or Pages page.
 
 However, when a web component is invoked through the _RequestDispatcher_
 interface, any active transaction context must be propagated to the called
-servlet or server page.
+servlet or Pages page.
 
 ==== Transactions in Web Component Life Cycles
 
@@ -146,8 +146,8 @@ Transactions may not span web requests from a client on the network. If a web
 component starts a transaction in the _service_ or _doFilter_ method (or
 transactional interceptor of _service_ or _doFilter_ method), it must be
 completed before the _service_ or _doFilter_ method returns to the network
-client.footnote:[For a Jakarta™ Server Pages page, this requirement applies to
-the _service_ method of the equivalent Jakarta™ Server Pages page Implementation
+client.footnote:[For a Jakarta™ Pages page, this requirement applies to
+the _service_ method of the equivalent Jakarta™ Pages page Implementation
 Class.] Returning from the _service_ or _doFilter_ method to the
 network client with an active transaction context is an error. The web container
 is required to detect this error and abort the transaction.
@@ -232,7 +232,7 @@ Jakarta Connectors API.
 
 A Jakarta EE product must support a Jakarta Messaging provider as a
 transactional resource manager. The product must enable transactional Jakarta
-Messaging access from servlets, server pages, and enterprise beans.
+Messaging access from servlets, Pages pages, and enterprise beans.
 
 It must be possible to access the Jakarta Messaging provider from multiple
 application components within a single transaction. For example, a servlet may
@@ -244,7 +244,7 @@ transaction, and, finally, commit the transaction.
 
 A Jakarta EE product must support resource adapters that use _XATransaction_
 mode as transactional resource managers. The product must enable transactional
-access to the resource adapter from servlets, server pages, and enterprise
+access to the resource adapter from servlets, Pages pages, and enterprise
 beans.
 
 It must be possible to access the resource adapter from multiple application

--- a/specification/src/main/asciidoc/platform/cdi-ee-spec/decorators_ee.adoc
+++ b/specification/src/main/asciidoc/platform/cdi-ee-spec/decorators_ee.adoc
@@ -2,11 +2,11 @@
 
 == Decorators in Jakarta EE
 
-When running in Jakarta EE, the container must extend the rules defined for managed beans in <<decorators>> to EJB session beans.
+When running in Jakarta EE, the container must extend the rules defined for managed beans in <<decorators>> to session enterprise beans.
 
 [[decorator_bean_ee]]
 
 === Decorator beans in Jakarta EE
 
-Decorators of an EJB session bean must comply with the bean provider programming restrictions defined by the EJB specification.
-Decorators of an EJB stateful session bean must comply with the rules for instance passivation and conversational state defined by the EJB specification.
+Decorators of a session enteprise bean must comply with the bean provider programming restrictions defined by the Jakarta Enterprise Beans specification.
+Decorators of a stateful session enterprise bean must comply with the rules for instance passivation and conversational state defined by the Jakarta Enterprise Beans specification.

--- a/specification/src/main/asciidoc/platform/cdi-ee-spec/definition_ee.adoc
+++ b/specification/src/main/asciidoc/platform/cdi-ee-spec/definition_ee.adoc
@@ -20,7 +20,7 @@ When running in Jakarta EE, the container must extend the capabilities defined i
 
 === Bean types for Jakarta EE component
 
-As managed beans, EJB session beans may have multiple bean types depending on their client-visible types.
+As managed beans, session enterprise beans may have multiple bean types depending on their client-visible types.
 For instance, this session bean has only the local interfaces `BookShop` and `Auditable`, along with `Object`, as bean types, since the bean class is not a client-visible type.
                                                                                                                         
 [source, java]
@@ -39,12 +39,12 @@ The rules for determining the (unrestricted) set of bean types for Jakarta EE co
 
 === Scopes
 
-Jakarta EE components such as servlets, EJBs and JavaBeans do not have a well-defined _scope_.
+Jakarta EE components such as servlets, enterprise beans and JavaBeans do not have a well-defined _scope_.
 These components are either:
 
-* _singletons_, such as EJB singleton session beans, whose state is shared between all clients,
-* _stateless objects_, such as servlets and stateless session beans, which do not contain client-visible state, or
-* objects that must be explicitly created and destroyed by their client, such as JavaBeans and stateful session beans, whose state is shared by explicit reference passing between clients.
+* _singletons_, such as singleton session enterprise beans, whose state is shared between all clients,
+* _stateless objects_, such as servlets and stateless session enterprise beans, which do not contain client-visible state, or
+* objects that must be explicitly created and destroyed by their client, such as JavaBeans and stateful session enterprise beans, whose state is shared by explicit reference passing between clients.
 
 CDI scopes add to Jakarta EE these missing well-defined lifecycle context as defined in <<scopes>>.
 
@@ -60,11 +60,11 @@ When running in Jakarta EE, the implementations of the `@RequestScoped`, `@Appli
 
 When running in Jakarta EE, If the _bean discovery mode_ is `annotated`, the container must extend the rules defined in <<default_bean_discovery>> with:
 
-* bean classes of EJB sessions beans, are discovered, and
-* producer methods that are on an EJB session bean are discovered, and
-* producer fields that are on an EJB session bean are discovered, and
-* disposer methods that are on an EJB session bean are discovered, and
-* observer methods that are on an EJB session bean are discovered.
+* bean classes of sessions enterprise beans, are discovered, and
+* producer methods that are on a session enterprise bean are discovered, and
+* producer fields that are on a session enterprise bean are discovered, and
+* disposer methods that are on a session enterprise bean are discovered, and
+* observer methods that are on a session enterprise bean are discovered.
 
 
 [[names_ee]]
@@ -72,9 +72,9 @@ When running in Jakarta EE, If the _bean discovery mode_ is `annotated`, the con
 
 A bean with a name may be referred to by its name in Unified EL expressions.
 
-There is no relationship between the bean name of an EJB session bean and the EJB name of the bean.
+There is no relationship between the bean name of a session enterprise bean and the EJB name of the bean.
 
-Bean names allow the direct use of beans in JSP or JSF pages.
+Bean names allow the direct use of beans in Pages or Faces pages.
 For example, a bean with the name `products` could be used like this:
 
 [source, xml]
@@ -84,7 +84,7 @@ For example, a bean with the name `products` could be used like this:
 
 [[default_name_ee]]
 
-==== Default bean names for EJB session beans
+==== Default bean names for session enterprise beans
 
-In the circumstances listed in <<default_name>>, the rule for determining default name for an EJB session bean are defined in <<session_bean_name>>.
+In the circumstances listed in <<default_name>>, the rule for determining default name for a session enterprise bean are defined in <<session_bean_name>>.
 

--- a/specification/src/main/asciidoc/platform/cdi-ee-spec/el.adoc
+++ b/specification/src/main/asciidoc/platform/cdi-ee-spec/el.adoc
@@ -4,7 +4,7 @@
 [[el_resolution]]
 === Bean name resolution in EL expressions
 
-The container must provide a Unified EL `ELResolver` to the servlet engine and JSF implementation that resolves bean names using the rules of name resolution defined in <<name_resolution>> and resolving ambiguities according to <<ambig_names>>.
+The container must provide a Unified EL `ELResolver` to the servlet engine and Faces implementation that resolves bean names using the rules of name resolution defined in <<name_resolution>> and resolving ambiguities according to <<ambig_names>>.
 
 * If a name used in an EL expression does not resolve to any bean, the `ELResolver` must return a null value.
 * Otherwise, if a name used in an EL expression resolves to exactly one bean, the `ELResolver` must return a contextual instance of the bean, as defined in <<contextual_instance>>.

--- a/specification/src/main/asciidoc/platform/cdi-ee-spec/events_ee.adoc
+++ b/specification/src/main/asciidoc/platform/cdi-ee-spec/events_ee.adoc
@@ -4,16 +4,16 @@
 
 [[observer_methods_ee]]
 
-=== Observer methods in EJB session beans
+=== Observer methods in session enterprise beans
 
-An observer method may also be a non-abstract method of an EJB session bean class.
-It must be either a business method exposed by a local business interface of the EJB or a static method of the bean class.
+An observer method may also be a non-abstract method of a session enterprise bean class.
+It must be either a business method exposed by a local business interface of the enterprise bean or a static method of the bean class.
 
 [[observes_ee]]
 
-==== Declaring an observer method in an EJB
+==== Declaring an observer method in an enterprise bean
 
-If a non-static method of a session bean class has a parameter annotated `@Observes` or `@ObservesAsync`, and the method is not a business method exposed by a local business interface of the EJB, the container automatically detects the problem and treats it as a definition error.
+If a non-static method of a session bean class has a parameter annotated `@Observes` or `@ObservesAsync`, and the method is not a business method exposed by a local business interface of the enterprise bean, the container automatically detects the problem and treats it as a definition error.
 
 [[observer_method_invocation_context_ee]]
 
@@ -21,4 +21,4 @@ If a non-static method of a session bean class has a parameter annotated `@Obser
 
 When running in Jakarta EE, the container must extend the rules defined in <<observer_method_invocation_context>> and must also ensure that all kinds of observers are called in the same client security context as the invocation of `Event.fire()` or `Event.fireAsync()`.
 
-The transaction and security contexts for a business method exposed by a local business interface of an EJB session bean also depend upon the transaction attribute and `@RunAs` descriptor, if any.
+The transaction and security contexts for a business method exposed by a local business interface of a session enterprise bean also depend upon the transaction attribute and `@RunAs` descriptor, if any.

--- a/specification/src/main/asciidoc/platform/cdi-ee-spec/implementation_ee.adoc
+++ b/specification/src/main/asciidoc/platform/cdi-ee-spec/implementation_ee.adoc
@@ -5,9 +5,9 @@
 When running in Jakarta EE, the container must extend the rules defined in <<implementation>>, and must also provide built-in support for injection and contextual lifecycle management of the following kinds of bean:
 
 * Session beans
-* Resources (Jakarta EE resources, persistence contexts, persistence units, remote EJBs and web services)
+* Resources (Jakarta EE resources, persistence contexts, persistence units, remote enterprise beans and web services)
 
-Jakarta EE and embeddable EJB containers are required by the Jakarta EE and EJB specifications to support EJB session beans and the Jakarta EE component environment.
+Jakarta EE enterprise beans containers are required by the Jakarta EE and Jakarta Enterprise Beans specifications to support session enterprise beans and the Jakarta EE component environment.
 Other containers are not required to provide support for injection or lifecycle management of session beans or resources.
 
 [[managed_beans_ee]]
@@ -20,18 +20,18 @@ Other containers are not required to provide support for injection or lifecycle 
 
 When running in Jakarta EE, a top-level Java class is a managed bean if it meets requirements described in <<what_classes_are_beans>> or if it is defined to be a managed bean by any other Jakarta EE specification and if
 
-* It is not annotated with an EJB component-defining annotation or declared as an EJB bean class in `ejb-jar.xml`.
+* It is not annotated with an Jakarta Enterprise Beans component-defining annotation or declared as an enterprise bean class in `ejb-jar.xml`.
 
 
 
 [[session_beans]]
 
-=== EJB Session beans
+=== Session enterprise beans
 
-A _session bean_ is a bean that is implemented by a session bean with an EJB 3.x client view that is not annotated with `@Vetoed` or in a package annotated `@Vetoed`. The basic lifecycle and semantics of EJB session beans are defined by the EJB specification.
+A _session bean_ is a bean that is implemented by a session bean with an Jakarta Enterprise Beans 3.x client view that is not annotated with `@Vetoed` or in a package annotated `@Vetoed`. The basic lifecycle and semantics of session enterprise beans are defined by the Jakarta Enterprise Beans specification.
 
-A stateless session bean must belong to the `@Dependent` pseudo-scope. A singleton session bean must belong to either the `@ApplicationScoped` scope or to the `@Dependent` pseudo-scope. If a session bean specifies an illegal scope, the container automatically detects the problem and treats it as a definition error.
-A stateful session bean may have any scope.
+A stateless session enterprise bean must belong to the `@Dependent` pseudo-scope. A singleton session bean must belong to either the `@ApplicationScoped` scope or to the `@Dependent` pseudo-scope. If a session bean specifies an illegal scope, the container automatically detects the problem and treats it as a definition error.
+A stateful session enterprise bean may have any scope.
 
 When a contextual instance of a session bean is obtained via the dependency injection service, the behavior of `SessionContext.getInvokedBusinessInterface()` is specific to the container implementation.
 Portable applications should not rely upon the value returned by this method.
@@ -42,18 +42,18 @@ If the session bean class is a generic type, it must have scope `@Dependent`. If
 
 [[session_bean_ejb_remove_method]]
 
-==== EJB remove methods of session beans
+==== Enterprise bean remove methods of session beans
 
 If a session bean is a stateful session bean:
 
-* If the scope is `@Dependent`, the application _may_ call any EJB remove method of a contextual instance of the session bean.
-* Otherwise, the application _may not_ directly call any EJB remove method of any contextual instance of the session bean.
+* If the scope is `@Dependent`, the application _may_ call any enterprise bean remove method of a contextual instance of the session bean.
+* Otherwise, the application _may not_ directly call any enterprise bean remove method of any contextual instance of the session bean.
 
-The session bean is not required to have an EJB remove method in order for the container to destroy it.
+The session bean is not required to have an enterprise bean remove method in order for the container to destroy it.
 
-If the application directly calls an EJB remove method of a contextual instance of a session bean that is a stateful session bean and declares any scope other than `@Dependent`, an `UnsupportedOperationException` is thrown.
+If the application directly calls an enterprise bean remove method of a contextual instance of a session bean that is a stateful session bean and declares any scope other than `@Dependent`, an `UnsupportedOperationException` is thrown.
 
-If the application directly calls an EJB remove method of a contextual instance of a session bean that is a stateful session bean and has scope `@Dependent` then no parameters are passed to the method by the container.
+If the application directly calls an enterprise bean remove method of a contextual instance of a session bean that is a stateful session bean and has scope `@Dependent` then no parameters are passed to the method by the container.
 Furthermore, the container ignores the instance instead of destroying it when `Contextual.destroy()` is called, as defined in <<stateful_lifecycle>>.
 
 [[session_bean_types]]
@@ -72,8 +72,8 @@ The resulting set of bean types for a session bean consists only of <<legal_bean
 
 ==== Declaring a session bean
 
-A session bean does not require any special annotations apart from the component-defining annotation (or XML declaration) required by the EJB specification.
-The following EJBs are beans:
+A session bean does not require any special annotations apart from the component-defining annotation (or XML declaration) required by the Jakarta Enterprise Beans specification.
+The following enterprise beans are beans:
 
 [source, java]
 ----
@@ -145,57 +145,57 @@ For example, if the bean class is named `ProductList`, the default bean name is 
 
 [[producer_method_ee]]
 
-=== Producer methods on EJB session bean
+=== Producer methods on session enterprise bean
 
-A producer method defined in an EJB session bean follows the rules defined in <<producer_method>> with the following addition:
+A producer method defined in a session enterprise bean follows the rules defined in <<producer_method>> with the following addition:
 
-* A producer method defined in an EJB session bean must be either a business method exposed by a local business interface of the EJB or a static method of the bean class.
+* A producer method defined in a session enterprise bean must be either a business method exposed by a local business interface of the enterprise bean or a static method of the bean class.
 
 [[declaring_producer_method_ee]]
 
-==== Declaring a producer method in an EJB session bean
+==== Declaring a producer method in a session enterprise bean
 
-A producer method declaration in an EJB session bean follows the rules defined in <<declaring_producer_method>> with the following addition:
+A producer method declaration in a session enterprise bean follows the rules defined in <<declaring_producer_method>> with the following addition:
 
 * if a non-static method of a session bean class is annotated `@Produces`, and the method is not a business method exposed by a local business interface of the session bean, the container automatically detects the problem and treats it as a definition error.
 
 [[producer_field_ee]]
 
-=== Producer field on EJB session bean
+=== Producer field on a session enterprise bean
 
-A producer field defined in an EJB session bean follows the rules defined in <<producer_field>> with the following addition:
+A producer field defined in a session enterprise bean follows the rules defined in <<producer_field>> with the following addition:
 
-* A producer field defined in an EJB session bean must be a static field of the bean class.
+* A producer field defined in a session enterprise bean must be a static field of the bean class.
 
 [[declaring_producer_field_ee]]
 
-==== Declaring a producer field in an EJB session bean
+==== Declaring a producer field in a session enterprise bean
 
-A producer field declaration in an EJB session bean follows the rules defined in <<declaring_producer_field>> with the following addition:
+A producer field declaration in a session enterprise bean follows the rules defined in <<declaring_producer_field>> with the following addition:
 
-* If a non-static field of an EJB session bean class is annotated `@Produces`, the container automatically detects the problem and treats it as a definition error.
+* If a non-static field of a session enterprise bean class is annotated `@Produces`, the container automatically detects the problem and treats it as a definition error.
 
 [[disposer_method_ee]]
 
-=== Disposer methods on EJB session bean
+=== Disposer methods on a session enterprise bean
 
-A disposer method defined in an EJB session bean follows the rules defined in <<disposer_method>> with the following addition:
+A disposer method defined in a session enterprise bean follows the rules defined in <<disposer_method>> with the following addition:
 
-* A disposer method defined in an EJB session bean must be either a business method exposed by a local business interface of the EJB or a static method of the bean class.
+* A disposer method defined in a session enterprise bean must be either a business method exposed by a local business interface of the enterprise bean or a static method of the bean class.
 
 [[declaring_disposer_method_ee]]
 
-==== Declaring a disposer method on an EJB session bean
+==== Declaring a disposer method on a session enterprise bean
 
-A disposer method declaration in an EJB session bean follows the rules defined in <<declaring_disposer_method>> with the following addition:
+A disposer method declaration in a session enterprise bean follows the rules defined in <<declaring_disposer_method>> with the following addition:
 
-* If a non-static method of an EJB session bean class has a parameter annotated `@Disposes`, and the method is not a business method exposed by a local business interface of the session bean, the container automatically detects the problem and treats it as a definition error.
+* If a non-static method of a session enterprise bean class has a parameter annotated `@Disposes`, and the method is not a business method exposed by a local business interface of the session bean, the container automatically detects the problem and treats it as a definition error.
 
 [[javaee_components]]
 
 === Jakarta EE components
 
-Most Jakarta EE components support injection and interception, as defined in the Jakarta EE Platform, Specification, table EE.5-1, but are not considered beans (as defined by this specification). EJBs, as defined in <<session_beans>> are the exception.
+Most Jakarta EE components support injection and interception, as defined in the Jakarta EE Platform, Specification, table EE.5-1, but are not considered beans (as defined by this specification). Enterprise beans, as defined in <<session_beans>> are the exception.
 
 The instance used by the container to service an invocation of a Jakarta EE component will not be the same instance obtained when using `@Inject`, instantiated by the container to invoke a producer method, observer method or disposer method, or instantiated by the container to access the value of a producer field.
 It is recommended that Jakarta EE components should not define observer methods, producer methods, producer fields or disposer methods.
@@ -205,7 +205,7 @@ It is safe to annotate Jakarta EE components with `@Vetoed` to prevent them bein
 
 === Resources
 
-A _resource_ is a bean that represents a reference to a resource, persistence context, persistence unit, remote EJB or web service in the Jakarta EE component environment.
+A _resource_ is a bean that represents a reference to a resource, persistence context, persistence unit, remote enterprise bean or web service in the Jakarta EE component environment.
 
 By declaring a resource, we enable an object from the Jakarta EE component environment to be injected by specifying only its type and qualifiers at the injection point.
 For example, if `@CustomerDatabase` is a qualifier:
@@ -244,11 +244,11 @@ The producer field may be static.
 * For a Jakarta EE resource, `@Resource` must be specified.
 * For a persistence context, `@PersistenceContext` must be specified.
 * For a persistence unit, `@PersistenceUnit` must be specified.
-* For a remote EJB, `@EJB` must be specified.
+* For a remote enterprise bean, `@EJB` must be specified.
 * For a web service, `@WebServiceRef` must be specified.
 
 
-The injection annotation specifies the metadata needed to obtain the resource, entity manager, entity manager factory, remote EJB instance or web service reference from the component environment.
+The injection annotation specifies the metadata needed to obtain the resource, entity manager, entity manager factory, remote enterprise bean instance or web service reference from the component environment.
 
 [source, java]
 ----
@@ -299,7 +299,7 @@ The resulting set of bean types for a resource consists only of <<legal_bean_typ
 
 === Additional built-in beans
 
-A Jakarta EE or embeddable EJB container must provide the following built-in beans, all of which have qualifier `@Default`:
+A Jakarta EE enterprise beans container must provide the following built-in beans, all of which have qualifier `@Default`:
 
 * a bean with bean type `jakarta.transaction.UserTransaction`, allowing injection of a reference to the JTA `UserTransaction`, and
 
@@ -328,4 +328,4 @@ When running in Jakarta EE, the container must extend the rules defined for bean
 When running in Jakarta EE, the container must extend the rules defined for bean classes in <<initializer_methods>> to Jakarta EE component classes supporting injection.
 The container must also ensure that:
 
-* An initializer method defined in an EJB session bean is _not_ required to be a business method of the session bean.
+* An initializer method defined in a session enterprise bean is _not_ required to be a business method of the session bean.

--- a/specification/src/main/asciidoc/platform/cdi-ee-spec/inheritance_ee.adoc
+++ b/specification/src/main/asciidoc/platform/cdi-ee-spec/inheritance_ee.adoc
@@ -2,7 +2,7 @@
 
 === Inheritance of type-level metadata in Jakarta EE
 
-When running in Jakarta EE, the container must extend the rules defined for managed beans in <<type_level_inheritance>> to EJB session beans.
+When running in Jakarta EE, the container must extend the rules defined for managed beans in <<type_level_inheritance>> to session enterprise beans.
 
 
 
@@ -10,7 +10,7 @@ When running in Jakarta EE, the container must extend the rules defined for mana
 
 === Inheritance of member-level metadata in Jakarta EE
 
-When running in Jakarta EE, the container must extend the rules defined for managed beans in <<member_level_inheritance>> to EJB session beans.
+When running in Jakarta EE, the container must extend the rules defined for managed beans in <<member_level_inheritance>> to session enterprise beans.
 
 [[specialization_ee]]
 
@@ -20,4 +20,4 @@ When running in Jakarta EE, the container must extend the rules defined for mana
 
 ==== Direct and indirect specialization in Jakarta EE
 
-When running in Jakarta EE, the container must extend the rules defined in <<member_level_inheritance>> and is also required to support specialization for EJB session beans as defined in <<specialize_session_bean>>.
+When running in Jakarta EE, the container must extend the rules defined in <<member_level_inheritance>> and is also required to support specialization for session enterprise beans as defined in <<specialize_session_bean>>.

--- a/specification/src/main/asciidoc/platform/cdi-ee-spec/injectionandresolution_ee.adoc
+++ b/specification/src/main/asciidoc/platform/cdi-ee-spec/injectionandresolution_ee.adoc
@@ -12,26 +12,26 @@ When resolving a name in an EL expression, the container considers the bean name
 
 In the Jakarta EE module architecture, any Jakarta EE module or library is a module. The Jakarta EE module is a bean archive if it contains a `beans.xml` file, as defined in <<bean_archive_full>>.
 
-When running in Jakarta EE, the container must follow the same accessibility rules for beans and alternatives defined in <<selection>> for JSP/JSF pages using EL resolution and make sure that only beans available from injection in the module that defines the JSP/JSF pages are resolved.
+When running in Jakarta EE, the container must follow the same accessibility rules for beans and alternatives defined in <<selection>> for Pages/Faces pages using EL resolution and make sure that only beans available from injection in the module that defines the Pages/Faces pages are resolved.
 
 In the Jakarta EE module architecture, a bean class is accessible in a module if and only if it is required to be accessible according to the class loading requirements defined by the Jakarta EE platform specification.
 
 Note that, in some Jakarta EE implementations, a bean class might be accessible to some other class even when this is not required by the Jakarta EE platform specification.
 For the purposes of this specification, a class is not considered accessible to another class unless accessibility is explicitly required by the Jakarta EE platform specification.
 
-An alternative is not available for injection, lookup or EL resolution to classes or JSP/JSF pages in a module unless the module is a bean archive and the alternative is explicitly _selected_ for the bean archive or the application.
+An alternative is not available for injection, lookup or EL resolution to classes or Pages/Faces pages in a module unless the module is a bean archive and the alternative is explicitly _selected_ for the bean archive or the application.
 
 [[declaring_selected_alternatives_application_ee]]
 
 ==== Declaring selected alternatives for an application in Jakarta EE
 
-When running in Jakarta EE, the container must extend the rules defined for managed beans in <<declaring_selected_alternatives_application>> to EJB session beans.
+When running in Jakarta EE, the container must extend the rules defined for managed beans in <<declaring_selected_alternatives_application>> to session enterprise beans.
 
 [[declaring_selected_alternatives_bean_archive_ee]]
 
 ==== Declaring selected alternatives for a bean archive in Jakarta EE
 
-When running in Jakarta EE, the container must extend the rules defined for managed beans in <<declaring_selected_alternatives_bean_archive>> to EJB session beans.
+When running in Jakarta EE, the container must extend the rules defined for managed beans in <<declaring_selected_alternatives_bean_archive>> to session enterprise beans.
 
 [[unsatisfied_and_ambig_dependencies_ee]]
 
@@ -48,7 +48,7 @@ When running in Jakarta EE, the container must extend the rules defined in <<nam
 An EL name resolves to a bean if:
 
 * the name can be resolved to a bean according to rules in <<name_resolution>>, and
-* the bean is available for injection in the war containing the JSP or JSF page with the EL expression.
+* the bean is available for injection in the war containing the Pages or Faces page with the EL expression.
 
 [[ambig_names_ee]]
 
@@ -62,11 +62,11 @@ When running in Jakarta EE, the container must extend the rules defined in <<amb
 
 When running in Jakarta EE, the container must extend the rules defined in <<injection>> and is also required to perform dependency injection whenever it creates the following contextual objects:
 
-* contextual instances of EJB session beans.
+* contextual instances of session enterprise beans.
 
 The container is also required to perform dependency injection whenever it instantiates any of the following non-contextual objects:
 
-* non-contextual instances of EJB session beans (for example, session beans obtained by the application from JNDI or injected using `@EJB`), and
+* non-contextual instances of session enterprise beans (for example, session beans obtained by the application from JNDI or injected using `@EJB`), and
 * instances of any other Jakarta EE component class supporting injection.
 
 A Java EE 5 container is not required to support injection for non-contextual objects.
@@ -75,13 +75,13 @@ A Java EE 5 container is not required to support injection for non-contextual ob
 
 ==== Injection using the bean constructor in Jakarta EE
 
-When running in Jakarta EE, the container must extend the rules defined for managed beans in <<instantiation>> to EJB session beans.
+When running in Jakarta EE, the container must extend the rules defined for managed beans in <<instantiation>> to session enterprise beans.
 
 [[fields_initializer_methods_ee]]
 
 ==== Injection of fields and initializer methods in Jakarta EE
 
-When running in Jakarta EE, the container must extend the rules defined for managed beans in <<fields_initializer_methods>> to EJB session beans and to any other Jakarta EE component class supporting injection.
+When running in Jakarta EE, the container must extend the rules defined for managed beans in <<fields_initializer_methods>> to session enterprise beans and to any other Jakarta EE component class supporting injection.
 
 The container is also required to ensure that:
 

--- a/specification/src/main/asciidoc/platform/cdi-ee-spec/interceptors_ee.adoc
+++ b/specification/src/main/asciidoc/platform/cdi-ee-spec/interceptors_ee.adoc
@@ -2,7 +2,7 @@
 
 == Interceptor bindings in Jakarta EE
 
-EJB session and message-driven beans support interception as defined in <<interceptors>>.
+Session and message-driven enterprise beans support interception as defined in <<interceptors>>.
 
 [[enabled_interceptors_ee]]
 
@@ -18,4 +18,4 @@ When running in Jakarta EE, the container must extend the rules defined in <<ena
 
 === Interceptor resolution in Jakarta EE
 
-For a custom implementation of the `Interceptor` interface defined in <<interceptor>>, the container also calls `intercepts()` to determine if the interceptor intercepts an EJB timeout method invocation.
+For a custom implementation of the `Interceptor` interface defined in <<interceptor>>, the container also calls `intercepts()` to determine if the interceptor intercepts an enterprise bean timeout method invocation.

--- a/specification/src/main/asciidoc/platform/cdi-ee-spec/lifecycle_ee.adoc
+++ b/specification/src/main/asciidoc/platform/cdi-ee-spec/lifecycle_ee.adoc
@@ -8,59 +8,59 @@
 
 When the application invokes:
 
-* a business method of a session bean via an EJB remote or local reference,
+* a business method of a session bean via an enterprise bean remote or local reference,
 
 the invocation is treated as a _business method invocation_.
 
 When running in Jakarta EE, the container must extend the rules defined in <<biz_method>>, with:
 
-* Invocation of EJB timer service timeouts by the container are not business method invocations, but are intercepted by interceptors for EJB timeouts.
-* Only an invocation of business method on an EJB session bean is subject to EJB services such as declarative transaction management, concurrency, security and asynchronicity, as defined by the EJB specification.
+* Invocation of Jakarta Enterprise Beans timer service timeouts by the container are not business method invocations, but are intercepted by interceptors for enterprise bean timeouts.
+* Only an invocation of business method on a session enterprise bean is subject to Jakarta Enterprise Beans services such as declarative transaction management, concurrency, security and asynchronicity, as defined by the Jakarta Enterprise Beans specification.
 * Additionally, invocations of message listener methods of message-driven beans during message delivery are passed through method interceptors.
 
 
 [[stateful_lifecycle]]
 
-==== Lifecycle of EJB stateful session beans
+==== Lifecycle of stateful session enterprise beans
 
-When the `create()` method of a `Bean` object that represents an EJB stateful session bean that is called, the container creates and returns a container-specific internal local reference to a new EJB session bean instance. The reference must be passivation capable. This reference is not directly exposed to the application.
-When the `create()` method of a `Bean` object that represents an EJB stateful session bean that is called, the container creates and returns a container-specific internal local reference to a new EJB session bean instance. The reference must be passivation capable. This reference is not directly exposed to the application.
+When the `create()` method of a `Bean` object that represents a stateful session enterprise bean that is called, the container creates and returns a container-specific internal local reference to a new session enterprise bean instance. The reference must be passivation capable. This reference is not directly exposed to the application.
+When the `create()` method of a `Bean` object that represents a stateful session enterprise bean that is called, the container creates and returns a container-specific internal local reference to a new session enterprise bean instance. The reference must be passivation capable. This reference is not directly exposed to the application.
 
-Before injecting or returning a contextual instance to the application, the container transforms its internal reference into an object that implements the bean types expected by the application and delegates method invocations to the underlying EJB stateful session bean instance. This object must be passivation capable.
+Before injecting or returning a contextual instance to the application, the container transforms its internal reference into an object that implements the bean types expected by the application and delegates method invocations to the underlying stateful session enterprise bean instance. This object must be passivation capable.
 
-When the `destroy()` method is called, and if the underlying EJB was not already removed by direct invocation of a remove method by the application, the container removes the EJB stateful session bean.
+When the `destroy()` method is called, and if the underlying enterprise bean was not already removed by direct invocation of a remove method by the application, the container removes the stateful session enterprise bean.
 The `@PreDestroy` callback must be invoked by the container.
 
-Note that the container performs additional work when the underlying EJB is created and removed, as defined in <<injection>>
+Note that the container performs additional work when the underlying enterprise bean is created and removed, as defined in <<injection>>
 
 [[stateless_lifecycle]]
 
-==== Lifecycle of EJB stateless and singleton session beans
+==== Lifecycle of stateless and singleton session enterprise beans
 
-When the `create()` method of a `Bean` object that represents an EJB stateless session or singleton session bean is called, the container creates and returns a container-specific internal local reference to the EJB session bean.
+When the `create()` method of a `Bean` object that represents a stateless session or singleton session enterprise bean is called, the container creates and returns a container-specific internal local reference to the session enterprise bean.
 This reference is not directly exposed to the application.
 
-Before injecting or returning a contextual instance to the application, the container transforms its internal reference into an object that implements the bean types expected by the application and delegates method invocations to the underlying EJB session bean.
+Before injecting or returning a contextual instance to the application, the container transforms its internal reference into an object that implements the bean types expected by the application and delegates method invocations to the underlying session enterprise bean.
 This object must be passivation capable.
 
 When the `destroy()` method is called, the container simply discards this internal reference.
 
-Note that the container performs additional work when the underlying EJB is created and removed, as defined in <<injection>>
+Note that the container performs additional work when the underlying enterprise bean is created and removed, as defined in <<injection>>
 
 [[resource_lifecycle]]
 
 ==== Lifecycle of resources
 
-When the `create()` method of a `Bean` object that represents a resource is called, the container creates and returns a container-specific internal reference to the Jakarta EE component environment resource, entity manager, entity manager factory, remote EJB instance or web service reference. This reference is not directly exposed to the application.
+When the `create()` method of a `Bean` object that represents a resource is called, the container creates and returns a container-specific internal reference to the Jakarta EE component environment resource, entity manager, entity manager factory, remote enterprise bean instance or web service reference. This reference is not directly exposed to the application.
 
-Before injecting or returning a contextual instance to the application, the container transforms its internal reference into an object that implements the bean types expected by the application and delegates method invocations to the underlying resource, entity manager, entity manager factory, remote EJB instance or web service reference. This object must be passivation capable.
+Before injecting or returning a contextual instance to the application, the container transforms its internal reference into an object that implements the bean types expected by the application and delegates method invocations to the underlying resource, entity manager, entity manager factory, remote enterprise bean instance or web service reference. This object must be passivation capable.
 
 The container must perform ordinary Jakarta EE component environment injection upon any non-static field that functions as a resource declaration, as defined by the Jakarta EE Platform and Jakarta Annotations specifications.
 The container is not required to perform Jakarta EE component environment injection upon a static field.
 Portable applications should not rely upon the value of a static field that functions as a resource declaration.
 
-References to EJBs and web services are always dependent scoped and a new instance must be obtained for every injection performed.
+References to enterprise beans and web services are always dependent scoped and a new instance must be obtained for every injection performed.
 
 For an entity manager associated with a resource definition, it must behave as though it were injected directly using `@PersistenceContext`.
 
-When the `destroy()` method of a bean which represents a remote stateful EJB reference is called, the container will _not_ automatically destroy the EJB reference. The application must explicitly call the method annotated `@Remove`. This behavior differs to that specified in <<stateful_lifecycle>> for beans which represent a local stateful EJB reference
+When the `destroy()` method of a bean which represents a remote stateful enterprise bean reference is called, the container will _not_ automatically destroy the enterprise bean reference. The application must explicitly call the method annotated `@Remove`. This behavior differs to that specified in <<stateful_lifecycle>> for beans which represent a local stateful enterprise bean reference

--- a/specification/src/main/asciidoc/platform/cdi-ee-spec/packagingdeployment_ee.adoc
+++ b/specification/src/main/asciidoc/platform/cdi-ee-spec/packagingdeployment_ee.adoc
@@ -4,16 +4,16 @@
 
 
 [[bean_archive_ee]]
-=== Bean archive with EJB Session Beans
+=== Bean archive with Session Enterprise Beans
 
 When running in Jakarta EE, the container must extend the rules defined in <<bean_archive_full>> with:
 
-* An _implicit bean archive_ may also contain EJB session beans, and
-* EJB session bean should be considered as bean class with bean defining annotation when determining if an archive is an _implicit bean archive_.
+* An _implicit bean archive_ may also contain session enterprise beans, and
+* Session enterprise bean should be considered as bean class with bean defining annotation when determining if an archive is an _implicit bean archive_.
 
 When determining which archives are bean archives, the container must also consider:
 
-* EJB jars or application client jars
+* Enterprise bean jars or application client jars
 * The `WEB-INF/classes` directory of a war
 
 The container is not required to support application client jar bean archives.
@@ -29,30 +29,28 @@ Portable applications must have a `beans.xml` file in only one of the `WEB-INF` 
 
 The following additional rules apply regarding container search for beans:
 
-* In an application deployed as an ear, the container searches every bean archive bundled with or referenced by the ear, including bean archives bundled with or referenced by wars, EJB jars and rars contained in the ear.
-The bean archives might be library jars, EJB jars or war `WEB-INF/classes` directories.
+* In an application deployed as an ear, the container searches every bean archive bundled with or referenced by the ear, including bean archives bundled with or referenced by wars, enterprise bean jars and rars contained in the ear.
+The bean archives might be library jars, enterprise bean jars or war `WEB-INF/classes` directories.
 * In an application deployed as a war, the container searches every bean archive bundled with or referenced by the war.
 The bean archives might be library jars or the `WEB-INF/classes` directory.
-* In an application deployed as an EJB jar, the container searches the EJB jar, if it is a bean archive, and every bean archive referenced by the EJB jar.
+* In an application deployed as an enterprise bean jar, the container searches the enterprise bean jar, if it is a bean archive, and every bean archive referenced by the enterprise bean jar.
 * In an application deployed as a rar, the container searches every bean archive bundled with or referenced by the rar.
-* An embeddable EJB container searches each bean archive in the JVM classpath that is listed in the value of the embeddable container initialization property `jakarta.ejb.embeddable.modules`, or every bean archive in the JVM classpath if the property is not specified.
-The bean archives might be directories, library jars or EJB jars.
 
 
 [[type_bean_discovery_ee]]
 
-=== Type and Bean discovery for EJB
+=== Type and Bean discovery for Enterprise Beans
 
-In Jakarta EE, the container automatically discovers EJB session beans and other Jakarta EE component class supporting injection, in bean archives like it does for managed bean as defined in <<type_bean_discovery_full>>.
+In Jakarta EE, the container automatically discovers session enterprise beans and other Jakarta EE component class supporting injection, in bean archives like it does for managed bean as defined in <<type_bean_discovery_full>>.
 
 [[bean_discovery_steps_ee]]
 
 ==== Bean discovery in Jakarta EE
 
-When running in Jakarta EE, the container must extend the rules defined in <<bean_discovery_steps_full>> and must also discover each EJB session bean.
+When running in Jakarta EE, the container must extend the rules defined in <<bean_discovery_steps_full>> and must also discover each session enterprise bean.
 
 [[trimmed_bean_archive_ee]]
 
 ==== Trimmed bean archive in Jakarta EE
 
-When running in Jakarta EE, the container must extend the rules defined in <<trimmed_bean_archive>> and must ensure that EJB session beans are not removed from the set of discovered types.
+When running in Jakarta EE, the container must extend the rules defined in <<trimmed_bean_archive>> and must ensure that session enterprise beans are not removed from the set of discovered types.

--- a/specification/src/main/asciidoc/platform/cdi-ee-spec/scopescontext_ee.adoc
+++ b/specification/src/main/asciidoc/platform/cdi-ee-spec/scopescontext_ee.adoc
@@ -8,7 +8,7 @@
 
 When running in Jakarta EE, the container must extend the rules defined in <<dependent_context>> and must also ensure that if a bean is declared to have `@Dependent` scope:
 
-* When a Unified EL expression in a JSF or JSP page that refers to the bean by its bean name is evaluated, at most one instance of the bean is instantiated.
+* When a Unified EL expression in a Faces or Pages page that refers to the bean by its bean name is evaluated, at most one instance of the bean is instantiated.
 This instance exists to service just a single evaluation of the EL expression.
 It is reused if the bean name appears multiple times in the EL expression, but is never reused when the EL expression is evaluated again, or when another EL expression is evaluated.
 
@@ -24,13 +24,13 @@ When running in Jakarta EE, the container must extend the rules defined for bean
 
 When running in Jakarta EE, the container must extend the rules defined for bean in <<dependent_destruction>> to Jakarta EE component class instance, and must also ensure that :
 
-* all `@Dependent` scoped contextual instances created during evaluation of a Unified EL expression in a JSP or JSF page are destroyed when the evaluation completes.
+* all `@Dependent` scoped contextual instances created during evaluation of a Unified EL expression in a Pages or Faces page are destroyed when the evaluation completes.
 
 [[dependent_scope_el]]
 
 ==== Dependent pseudo-scope and Unified EL
 
-Suppose a Unified EL expression in a JSF or JSP page refers to a bean with scope `@Dependent` by its bean name. Each time the EL expression is evaluated:
+Suppose a Unified EL expression in a Faces or Pages page refers to a bean with scope `@Dependent` by its bean name. Each time the EL expression is evaluated:
 
 * the bean is instantiated at most once, and
 * the resulting instance is reused for every appearance of the bean name, and
@@ -48,10 +48,10 @@ Portable extensions that integrate with the container via Unified EL should also
 
 ==== Passivation capable beans in Jakarta EE
 
-* As defined by the EJB specification, an EJB stateful session beans is passivation capable if:
+* As defined by the Jakarta Enterprise Beans specification, a stateful session enterprise bean is passivation capable if:
 ** interceptors and decorators of the bean are passivation capable, and,
-** the EJB stateful session bean does not have the `passivationCapable` flag set to `false`.
-* As defined by the EJB specification, an EJB stateless session bean or an EJB singleton session bean is not passivation capable.
+** the stateful session enterprise bean does not have the `passivationCapable` flag set to `false`.
+* As defined by the Jakarta Enterprise Beans specification, a stateless session enterprise bean or a singleton session enterprise bean is not passivation capable.
 
 [[passivation_capable_dependency_ee]]
 
@@ -59,16 +59,16 @@ Portable extensions that integrate with the container via Unified EL should also
 
 When running in Jakarta EE, the container must extend the rules defined in <<passivation_capable_dependency>>, and must also guarantee that:
 
-* all EJB stateless session beans are passivation capable dependencies,
-* all EJB singleton session beans are passivation capable dependencies,
-* all passivation capable EJB stateful session beans are passivation capable dependencies, and
+* all stateless session enterprise beans are passivation capable dependencies,
+* all singleton session enterprise beans are passivation capable dependencies,
+* all passivation capable stateful session enterprise beans are passivation capable dependencies, and
 * all Jakarta EE resources are passivation capable dependencies.
 
 [[passivation_validation_ee]]
 
 ==== Validation of passivation capable beans and dependencies in Jakarta EE
 
-When running in Jakarta EE, the container must extend the rules defined for managed beans in <<passivation_validation>> to EJB session beans.
+When running in Jakarta EE, the container must extend the rules defined for managed beans in <<passivation_validation>> to session enterprise beans.
 
 [[builtin_contexts_ee]]
 
@@ -76,7 +76,7 @@ When running in Jakarta EE, the container must extend the rules defined for mana
 
 When running in Jakarta EE, the container must extend the rules defined in <<builtin_contexts>> and is also required to ensure the following rules for built-in context implementation.
 
-The built-in request and application context objects are active during servlet, web service and EJB invocations, and the built in session and request context objects are active during servlet and web service invocations.
+The built-in request and application context objects are active during servlet, web service and enterprise bean invocations, and the built in session and request context objects are active during servlet and web service invocations.
 
 [[request_context_ee]]
 
@@ -88,14 +88,14 @@ The request context is active:
 
 * during the `service()` method of any servlet in the web application, during the `doFilter()` method of any servlet filter and when the container calls any `ServletRequestListener` or `AsyncListener`,
 * during any Jakarta EE web service invocation,
-* during any remote method invocation of any EJB, during any asynchronous method invocation of any EJB, during any call to an EJB timeout method and during message delivery to any EJB message-driven bean.
+* during any remote method invocation of any enterprise bean, during any asynchronous method invocation of any enterprise bean, during any call to an enterprise bean timeout method and during message delivery to any message-driven enterprise bean.
 
 
 The request context is destroyed:
 
 * at the end of the servlet request, after the `service()` method, all `doFilter()` methods, and all `requestDestroyed()` and `onComplete()` notifications return,
 * after the web service invocation completes,
-* after the EJB remote method invocation, asynchronous method invocation, timeout or message delivery completes if it did not already exist when the invocation occurred.
+* after the enterprise bean remote method invocation, asynchronous method invocation, timeout or message delivery completes if it did not already exist when the invocation occurred.
 
 The payload of the event fired when the request context is initialized or destroyed is:
 
@@ -132,12 +132,12 @@ The application scope is active:
 * during the `service()` method of any servlet in the web application, during the `doFilter()` method of any servlet filter and when the container calls any `ServletContextListener`, `HttpSessionListener`, `AsyncListener` or `ServletRequestListener`,
 * during any Jakarta EE web service invocation,
 * during any asynchronous invocation of an event observer,
-* during any remote method invocation of any EJB, during any asynchronous method invocation of any EJB, during any call to an EJB timeout method and during message delivery to any EJB message-driven bean,
+* during any remote method invocation of any enterprise bean, during any asynchronous method invocation of any enterprise bean, during any call to an enterprise bean timeout method and during message delivery to any message-driven enterprise bean,
 * when the disposer method or `@PreDestroy` callback of any bean with any normal scope other than `@ApplicationScoped` is called, and
 * during `@PostConstruct` callback of any bean.
 
 
-The application context is shared between all servlet requests, web service invocations, asynchronous invocation of an event observer, EJB remote method invocations, EJB asynchronous method invocations, EJB timeouts and message deliveries to message-driven beans that execute within the same application.
+The application context is shared between all servlet requests, web service invocations, asynchronous invocation of an event observer, enterprise bean remote method invocations, enterprise bean asynchronous method invocations, enterprise bean timeouts and message deliveries to message-driven beans that execute within the same application.
 The application context is destroyed when the application is shut down.
 
 The payload of the event fired when the application context is initialized or destroyed is:
@@ -188,10 +188,10 @@ If the conversation associated with the current Servlet request is in the _long-
 The long-running conversation associated with a request may be propagated to any Servlet request via use of a request parameter named `cid` containing the unique identifier of the conversation.
 In this case, the application must manage this request parameter.
 
-If the current Servlet request is a JSF request, and the conversation is in _long-running_ state, it is propagated according to the following rules:
+If the current Servlet request is a Faces request, and the conversation is in _long-running_ state, it is propagated according to the following rules:
 
-* The long-running conversation context associated with a request that renders a JSF view is automatically propagated to any faces request (JSF form submission) that originates from that rendered page.
-* The long-running conversation context associated with a request that results in a JSF redirect (a redirect resulting from a navigation rule or JSF `NavigationHandler`) is automatically propagated to the resulting non-faces request, and to any other subsequent request to the same URL.
+* The long-running conversation context associated with a request that renders a Faces view is automatically propagated to any faces request (Faces form submission) that originates from that rendered page.
+* The long-running conversation context associated with a request that results in a Faces redirect (a redirect resulting from a navigation rule or Faces `NavigationHandler`) is automatically propagated to the resulting non-faces request, and to any other subsequent request to the same URL.
 This is accomplished via use of a request parameter named `cid` containing the unique identifier of the conversation.
 
 

--- a/specification/src/main/asciidoc/platform/cdi-ee-spec/spi_ee.adoc
+++ b/specification/src/main/asciidoc/platform/cdi-ee-spec/spi_ee.adoc
@@ -6,7 +6,7 @@
  
 === The `Bean` interface in Jakarta EE
  
-When running in Jakarta EE, the container must extend the rules defined in <<bean>> for managed bean to EJB session bean.
+When running in Jakarta EE, the container must extend the rules defined in <<bean>> for managed bean to session enterprise bean.
 
 [[interceptor_ee]]
 
@@ -14,7 +14,7 @@ When running in Jakarta EE, the container must extend the rules defined in <<bea
 
 When running in Jakarta EE, the container must extend the rules defined in <<interceptor>> and must also ensure that
  
-`PRE_PASSIVATE`, `POST_ACTIVATE` and `AROUND_TIMEOUT` InterceptorType values are linked to EJB lifecycle callback or timeout method.
+`PRE_PASSIVATE`, `POST_ACTIVATE` and `AROUND_TIMEOUT` InterceptorType values are linked to enterprise bean lifecycle callback or timeout method.
 
 
 [[injectiontarget_ee]]
@@ -42,11 +42,11 @@ Jakarta EE Components may obtain an instance of `BeanManager` from JNDI by looki
 
 [[alternative_metadata_sources_ee]]
 
-=== Alternative metadata sources and EJB
+=== Alternative metadata sources and enterprise beans
 
 When running in Jakarta EE, the container must extend the rules defined in <<alternative_metadata_sources>> and ensure that:
 
-* when an `AnnotatedType` represents an EJB session bean class, `Annotated.getTypeClosure()` must returns the EJB session bean types as defined in <<session_bean_types>>.
+* when an `AnnotatedType` represents a session enterprise bean class, `Annotated.getTypeClosure()` must returns the session enterprise bean types as defined in <<session_bean_types>>.
 
 [[init_events_ee]]
 
@@ -56,21 +56,21 @@ When running in Jakarta EE, the container must extend the rules defined in <<alt
 
 ==== `ProcessAnnotatedType` event in Jakarta EE
 
-When running in Jakarta EE, the container must extend the rules defined in <<process_annotated_type>> to Jakarta EE component and EJB session bean classes.
+When running in Jakarta EE, the container must extend the rules defined in <<process_annotated_type>> to Jakarta EE component and session enterprise bean classes.
 
 [[process_injection_point_ee]]
 
-==== `ProcessInjectionPoint` event and EJB
+==== `ProcessInjectionPoint` event and enterprise beans
 
-When running in Jakarta EE, the container must also fire an event for every injection point of every Jakarta EE component class supporting injection that may be instantiated by the container at runtime, including every EJB session or message-driven bean.
+When running in Jakarta EE, the container must also fire an event for every injection point of every Jakarta EE component class supporting injection that may be instantiated by the container at runtime, including every session or message-driven enterprise bean.
 
 [[process_injection_target_ee]]
 
-==== `ProcessInjectionTarget` event and EJB
+==== `ProcessInjectionTarget` event and enterprise beans
 
-When running in Jakarta EE, the container must also fire an event for every Jakarta EE component class supporting injection that may be instantiated by the container at runtime, including every EJB session or message-driven bean.
+When running in Jakarta EE, the container must also fire an event for every Jakarta EE component class supporting injection that may be instantiated by the container at runtime, including every session or message-driven enterprise bean.
 
-The container must extend the rules defined in <<process_injection_target>> for managed bean to EJB session bean and other Jakarta EE component class supporting injection.
+The container must extend the rules defined in <<process_injection_target>> for managed bean to session enterprise bean and other Jakarta EE component class supporting injection.
 
 For example, this observer decorates the `InjectionTarget` for all servlets.
 
@@ -84,14 +84,14 @@ For example, this observer decorates the `InjectionTarget` for all servlets.
 
 [[process_bean_attributes_ee]]
 
-==== `ProcessBeanAttributes` event and EJB
+==== `ProcessBeanAttributes` event and enterprise beans
 
-When running in Jakarta EE, the container must extend the rules defined in <<process_bean_attributes>> to EJB session bean.
+When running in Jakarta EE, the container must extend the rules defined in <<process_bean_attributes>> to session enterprise bean.
 
 
 [[process_bean_ee]]
 
-==== `ProcessBean` event and EJB
+==== `ProcessBean` event and enterprise beans
 
 In addition to definition given in <<process_bean>> the following apply:
 

--- a/specification/src/main/asciidoc/webprofile/RelatedDocuments.adoc
+++ b/specification/src/main/asciidoc/webprofile/RelatedDocuments.adoc
@@ -16,7 +16,7 @@ _Java™ Platform, Standard Edition, v17 API Specification_. Available at: _http
 
 _Jakarta™ Enterprise Beans Specification, Version 4.0_. Available at: _https://jakarta.ee/specifications/enterprise-beans/4.0/_
 
-_Jakarta™ Server Pages Specification, Version 4.0_. Available at: _https://jakarta.ee/specifications/pages/4.0/_
+_Jakarta™ Pages Specification, Version 4.0_. Available at: _https://jakarta.ee/specifications/pages/4.0/_
 
 _Jakarta™ Expression Language Specification, Version 6.0_. Available at: _https://jakarta.ee/specifications/expression-language/6.0/_
 
@@ -32,7 +32,7 @@ _Jakarta™ Debugging Support for Other Languages Specification, Version 2.0_. A
 
 _Jakarta™ Standard Tag Library Specification, Version 3.0_. Available at: _https://jakarta.ee/specifications/tags/3.0/_
 
-_Jakarta™ Server Faces Specification, Version 4.1_. Available at: _https://jakarta.ee/specifications/faces/4.1/_
+_Jakarta™ Faces Specification, Version 4.1_. Available at: _https://jakarta.ee/specifications/faces/4.1/_
 
 _Jakarta™ Persistence Specification, Version 3.2_. Available at: _https://jakarta.ee/specifications/persistence/3.2/_
 

--- a/specification/src/main/asciidoc/webprofile/WebProfileDefinition.adoc
+++ b/specification/src/main/asciidoc/webprofile/WebProfileDefinition.adoc
@@ -17,6 +17,7 @@ The following technologies are required components of the Web Profile:
 * Jakarta Dependency Injection 2.0
 * Jakarta Enterprise Beans 4.0 Lite
 * Jakarta Expression Language 6.0*
+* Jakarta Faces 4.1*
 * Jakarta Interceptors 2.2*
 * Jakarta JSON Binding 3.0
 * Jakarta JSON Processing 2.1
@@ -24,7 +25,6 @@ The following technologies are required components of the Web Profile:
 * Jakarta Persistence 3.2*
 * Jakarta RESTful Web Services 4.0*
 * Jakarta Security 4.0*
-* Jakarta Server Faces 4.1*
 * Jakarta Servlet 6.1*
 * Jakarta Standard Tag Library 3.0
 * Jakarta Transactions 2.0


### PR DESCRIPTION
- Update specification names to use their updated names
- Remove EJB Home and embeddable container references
- Update architecture graphic to remove Managed Beans and XML WS technologies and add in Data.  Similar to what was done with #611, but for EE 11
- Fix the wording of the initial sentences of the Changes in Jakarta EE 10 and 11 sections for #994

Fixes #895
Fixes #994