### PR TITLE
Updates related to Web Profile, JPA / CDI integration and others

### DIFF
--- a/specification/src/main/asciidoc/platform-spec.adoc
+++ b/specification/src/main/asciidoc/platform-spec.adoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017-2024 Contributors to the Eclipse Foundation
+// Copyright (c) 2017-2025 Contributors to the Eclipse Foundation
 //
 
 = Jakarta EE Platform
@@ -14,7 +14,7 @@
 :sectnumlevels: 4
 :sectanchors:
 :inception-year: 2018
-:copyright-year: 2024
+:copyright-year: 2025
 ifdef::backend-pdf[]
 :pagenums:
 :numbered:

--- a/specification/src/main/asciidoc/platform/cdi-ee-spec/CDI-JPA.adoc
+++ b/specification/src/main/asciidoc/platform/cdi-ee-spec/CDI-JPA.adoc
@@ -1,21 +1,21 @@
 :cdi-spec: https://jakarta.ee/specifications/cdi/4.1/
 :jpa-spec: https://jakarta.ee/specifications/persistence/3.2/
-:platform-profile: https://jakarta.ee/specifications/platform/11/
+:platform-spec: https://jakarta.ee/specifications/platform/11/
 [[a441]]
-=== Jakarta Persistence & Jakarta Context and Dependency Injection (CDI) Integration
+== Jakarta Persistence & Jakarta Context and Dependency Injection (CDI) Integration
 This section specifies the requirements for Jakarta EE environments that integrate both {jpa-spec}[Persistence] and {cdi-spec}[CDI].
 
 Several of the items described in this section are also available with
 the following additional access methods, as specified in the sections
 **Persistence Unit References** and **Persistence Context References**
-of the {platform-profile}[Jakarta EE Platform Specification].
+of the {platform-spec}[Jakarta EE Platform Specification].
 
 - the _@Resource_ annotation with the JNDI _lookup_ attribute.
 - the JNDI lookup using JNDI API.
 
 The items available with these additional access methods are indicated inline.
 
-==== Obtaining an Entity Manager using CDI
+=== Obtaining an Entity Manager using CDI
 
 A Jakarta EE container must feature built-integration of
 Jakarta Persistence with the CDI bean manager, allowing
@@ -39,7 +39,7 @@ this specification for a container-managed entity manager.
 _EntityManager_ must also be available via the additional access
 methods specified at the beginning of this section.
 
-==== Injecting an Entity Manager Factory using CDI
+=== Injecting an Entity Manager Factory using CDI
 
 A Jakarta EE container must feature built-in integration of Jakarta
 Persistence with the CDI bean manager, allowing injection
@@ -78,7 +78,7 @@ the _EntityManagerFactory_ bean.
 
 - To access these bean types (_CriteriaBuilder_, _PersistenceUnitUtil_, _Cache_, _SchemaManager_, and _Metamodel_) from callsites that use _@Resource_ or JNDI lookup, users must first obtain the _EntityManagerFactory_ and then use the appropriate getter methods.
 
-==== persistence.xml Extended Schema
+=== persistence.xml Extended Schema
 The Persistence specification schema includes an extension point that allows one to add elements for configuration of integration concerns. The required approach for declaring a CDI  scope and qualifier elements is to use the cdi:scope and cdi:qualifier persistence-unit child elements. Its usage is illustrated in the following XML document.
 
 [source,xml]
@@ -108,7 +108,7 @@ The Persistence specification schema includes an extension point that allows one
 </persistence>
 ----
 
-====  Additional _EntityManagerFactory_ Properties
+===  Additional _EntityManagerFactory_ Properties
 
 The following additional properties correspond to the
 new elements and properties in the _persistence.xml_ file when using the persistence-3.2 xsd schema and associated _persistenceUnitExtType_. When any of these

--- a/specification/src/main/asciidoc/platform/cdi-ee-spec/javaeeintegration.adoc
+++ b/specification/src/main/asciidoc/platform/cdi-ee-spec/javaeeintegration.adoc
@@ -32,4 +32,6 @@ include::packagingdeployment_ee.adoc[]
 
 include::el.adoc[]
 
+include::CDI-JPA.adoc[]
+
 include::xrefs.adoc[]

--- a/specification/src/main/asciidoc/web-dependencies.adoc
+++ b/specification/src/main/asciidoc/web-dependencies.adoc
@@ -1,3 +1,5 @@
+[appendix]
+
 == Jakarta EE 11 Web Profile Dependencies
 
 [graphviz]
@@ -8,15 +10,15 @@ digraph EE11WebProfile {
 wp [label="jakarta-web-api"];
 servlet [label="servlet:6.1.0"];
 jsp [label="servlet.jsp:4.0.0"];
-el [label="el:6.0.0"];
-jstl [label="servlet.jsp.jstl:3.0.0"];
-faces [label="faces:4.1.0"];
+el [label="el:6.0.1"];
+jstl [label="servlet.jsp.jstl:3.0.2"];
+faces [label="faces:4.1.2"];
 jaxrs [label="jaxrs:4.0.0"]
 websocket [label="websocket:2.2.0"];
-jsonp [label="jsonp:2.1.0"];
-jsonb [label="jsonb:3.0.0"];
+jsonp [label="jsonp:2.1.3"];
+jsonb [label="jsonb:3.0.1"];
 annotations [label="annotations:3.0.0"];
-ejb [label="ejb:4.0.0"];
+ejb [label="ejb:4.0.1"];
 jta [label="jta:2.0.1"];
 jpa [label="jpa:3.2.0"];
 validation [label="validation:3.1.0"];
@@ -25,8 +27,8 @@ cdi [label="cdi:4.1.0"];
 di [label="di:2.0.1"];
 authn [label="authentication:3.1.0"];
 security [label="security:4.0.0"];
-concurrency [label="concurrent:3.1.0"];
-data [label="data:1.0.0"];
+concurrency [label="concurrent:3.1.1"];
+data [label="data:1.0.1"];
 
 wp -> servlet;
 wp -> jsp;
@@ -66,8 +68,6 @@ faces -> el;
 faces -> cdi;
 faces -> validation;
 faces -> jta;
-faces -> jsp;
-faces -> jstl;
 faces -> jsonp;
 faces -> ejb;
 faces -> jpa;

--- a/specification/src/main/asciidoc/webprofile-spec.adoc
+++ b/specification/src/main/asciidoc/webprofile-spec.adoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017-2024 Contributors to the Eclipse Foundation
+// Copyright (c) 2017-2025 Contributors to the Eclipse Foundation
 //
 
 = Jakarta EE Web Profile
@@ -14,7 +14,7 @@
 :sectnumlevels: 4
 :sectanchors:
 :inception-year: 2018
-:copyright-year: 2024
+:copyright-year: 2025
 ifdef::backend-pdf[]
 :pagenums:
 :numbered:
@@ -32,6 +32,6 @@ include::license-efsl.adoc[]
 :sectnums:
 include::webprofile/WebProfile.adoc[]
 
-// == Dependencis
+// == Dependencies
 :sectnums:
 include::web-dependencies.adoc[]

--- a/specification/src/main/asciidoc/webprofile/RevisionHistory.adoc
+++ b/specification/src/main/asciidoc/webprofile/RevisionHistory.adoc
@@ -5,6 +5,7 @@
 * Updated Java SE base version to 17.
 * Addition of Jakarta Data to Web Profile.
 * Updated <<relateddocs, “Related Documents">> for the updated Specifications in Jakarta EE 11.
+* Add "Component Specification Integration Requirements" chapter mostly coming from the CDI specification.
 
 === Changes in Final Release for Jakarta EE 10
 * Major and minor updates to most specifications.

--- a/specification/src/main/asciidoc/webprofile/WebProfile.adoc
+++ b/specification/src/main/asciidoc/webprofile/WebProfile.adoc
@@ -1,11 +1,9 @@
 include::Introduction.adoc[]
 
-include::../shared-includes/IntegrationRequirements.adoc[]
-
 include::WebProfileDefinition.adoc[]
 
-include::RevisionHistory.adoc[]
+include::../shared-includes/IntegrationRequirements.adoc[]
 
-include::WebProfileIntegration.adoc[]
+include::RevisionHistory.adoc[]
 
 include::RelatedDocuments.adoc[]

--- a/specification/src/main/asciidoc/webprofile/WebProfileIntegration.adoc
+++ b/specification/src/main/asciidoc/webprofile/WebProfileIntegration.adoc
@@ -1,5 +1,0 @@
-== Integration Requirements
-
-This section of the Web Profile defines integration requirements for specifications included in the Web Profile
-
-include::jpa-cdi/CDI-JPA.adoc[]


### PR DESCRIPTION
- Update copyright to include 2025 since that is when the platform and web profile will be created for publishing
- Move CDI-JPA integration section under the section for integration between components (CDI EE section) so there aren't two sections related to component integration
- Update version numbers for Web Profile dependencies graphic and mark it as an appendix instead of another chapter after the appendixes.
- Fix the ordering of the chapters for Web Profile to have the new chapter be chapter 3

FYI @starksm64 , @ivargrimstad , @edburns , @arjantijms 