### PR TITLE
Remove extra space

### DIFF
--- a/specification/src/main/asciidoc/platform/Security.adoc
+++ b/specification/src/main/asciidoc/platform/Security.adoc
@@ -136,7 +136,7 @@ Invoking Enterprise Bean Business Methods::
 The Pages page performs the remote method call to
 the enterprise bean, using the user’s credential to establish a secure
 association between the Pages page and the enterprise bean (as shown in
-<<a269, Invoking an Enterprise Bean Business Method>> ). 
+<<a269, Invoking an Enterprise Bean Business Method>>).
 The association is implemented as two related
 security contexts, one in the web server and one in the Jakarta Enterprise Beans container.
 


### PR DESCRIPTION
Currently, depending on view, the line is broken before closing `)`:
<img width="978" height="63" alt="current" src="https://github.com/user-attachments/assets/102e9539-75e2-4950-85eb-dd46b3f34d21" />
With this space removed, the line is broken between words:
<img width="978" height="63" alt="pr" src="https://github.com/user-attachments/assets/1ff297ba-1f59-4422-9b6c-8bd759bc5e61" />
